### PR TITLE
Feature/smart prompt storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to `copt` (Claude Prompt Optimizer) will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-02-15
+
+### Added
+
+- **Smart prompt naming**: Saved prompts now use descriptive filenames derived from prompt content (e.g., `dashboard-analytics-api_143022_optimized.txt`) instead of generic `optimized_HHMMSS.txt`
+- **Centralized prompt storage**: Default save location changed from `./copt-output/` to `~/.copt/prompts/YYYY-MM-DD/` — date-bucketed, centralized across all invocations
+- **`name` field in JSON output**: `--format json` and metadata files now include a `name` field with the prompt slug
+- **Raycast script command**: `scripts/raycast/optimize-prompt.sh` — optimize clipboard prompts via Bedrock with a single Raycast keystroke
+
+### Changed
+
+- **`--output-dir` is now optional**: Defaults to `~/.copt/prompts` when not specified. Use `--output-dir <DIR>` to override.
+- **File naming convention**: `<slug>_<HHMMSS>_optimized.txt` / `_original.txt` / `.json` (was `optimized_<HHMMSS>.txt`)
+- **JSON format auto-saves**: `--format json` no longer suppresses auto-save (use `--no-save` explicitly)
+
+### Technical
+
+- New `generate_prompt_slug()` in `src/utils/text.rs` with LazyLock regex, 6 unit tests
+- Test suite: 91 → 97
+
+---
+
 ## [0.3.0] - 2026-02-14
 
 ### Added
@@ -295,7 +317,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/praveenc/copt/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/praveenc/copt/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/praveenc/copt/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/praveenc/copt/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/praveenc/copt/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/praveenc/copt/compare/v0.2.1...v0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "copt"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copt"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Praveen Chamarthi"]
 description = "Claude Prompt Optimizer - A beautiful CLI tool to optimize prompts for Claude 4.5 family of models"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ copt detects Claude 3.x patterns and rewrites them for Claude 4.5:
 + - Export functionality
 ```
 
-See [docs/RULES.md](docs/RULES.md) for the full list of 27 analysis rules across 8 categories.
+See [docs/RULES.md](docs/RULES.md) for the full list of 25 analysis rules across 8 categories.
 
 ---
 
@@ -129,9 +129,9 @@ Arguments:
 Options:
   -f, --file <FILE>              Read prompt from file
   -o, --output <FILE>            Save optimized prompt to file
-      --output-dir <DIR>         Output directory [default: copt-output]
+      --output-dir <DIR>         Output directory for auto-save
       --no-save                  Disable auto-save
-  -p, --provider <PROVIDER>      Provider: anthropic, bedrock [default: bedrock]
+  -p, --provider <PROVIDER>      Provider: anthropic, bedrock
   -m, --model <MODEL>            Model ID or alias
       --region <REGION>          AWS region for Bedrock
       --format <FORMAT>          Output format: pretty, json, quiet
@@ -141,10 +141,11 @@ Options:
       --analyze                  Analyze only, no optimization
       --offline                  Offline mode (no API calls)
       --check <CAT>              Check specific categories
-      --no-suggest               Disable auto-suggestions
-  -i, --interactive              Full-screen interactive TUI
-      --config-init              Create default config file and exit
+      --no-suggest               Disable auto-suggestions for vague prompts
+  -i, --interactive              Launch full-screen interactive TUI mode
+  -e, --editor                   Open editor for multi-line input
       --skip-connectivity-check  Skip connectivity check
+      --config-init              Create default config file and exit
   -v, --verbose                  Verbose output
   -h, --help                     Print help
   -V, --version                  Print version
@@ -198,6 +199,28 @@ copt -f prompt.txt -i
 | `c` | Copy to clipboard |
 | `s` / `e` | Save & open in editor |
 | `?` | Help |
+
+---
+
+## Prompt Storage
+
+Optimized prompts are auto-saved to `~/.copt/prompts/YYYY-MM-DD/` with descriptive filenames:
+
+```
+~/.copt/prompts/
+└── 2026-02-15/
+    ├── dashboard-analytics-api_143022_original.txt
+    ├── dashboard-analytics-api_143022_optimized.txt
+    └── dashboard-analytics-api_143022.json
+```
+
+Use `--output-dir <DIR>` to override, or `--no-save` to disable.
+
+---
+
+## Raycast Integration
+
+Optimize prompts directly from your clipboard. See [scripts/raycast/README.md](scripts/raycast/README.md) for setup.
 
 ---
 

--- a/docs/HANDOFF_PROMPT.md
+++ b/docs/HANDOFF_PROMPT.md
@@ -1,183 +1,79 @@
-# Handoff Prompt — COPT Improvement Session
+# Handoff Prompt — COPT
 
 ## Context
 
-You are continuing work on **COPT** (Claude Prompt Optimizer), a Rust CLI tool that analyzes and rewrites prompts for Claude 4.5 models. The project is at v0.2.3, functional, and in active use.
+**COPT** (Claude Prompt Optimizer) is a Rust CLI tool that analyzes and rewrites prompts for Claude 4.5 models. The project is at v0.3.1, functional, and in active use.
 
-A comprehensive code review was completed and documented in `docs/IMPROVEMENTS.md`. **Phases 1-4 are complete** on the `feature/dead-code-cleanup` branch. Only Phase 4.1 (expand static optimization coverage) remains as future work.
+## Current State
 
-## What Was Done
+Branch: `feature/smart-prompt-storage` (based on `main` at v0.3.0)
 
-Branch: `feature/dead-code-cleanup` (8 commits ahead of main, all pushed)
+### v0.3.0 (merged to main)
 
-### Phase 1: Dead Code Cleanup (4 commits)
+All improvements from `docs/IMPROVEMENTS.md` Phases 1-4 are complete:
 
-**Commit 1** (`89a5e26`): Remove 6 unused Cargo dependencies
-- Removed `tiktoken-rs`, `dotenvy`, `textwrap`, `unicode-segmentation`, `directories`, `futures`
+- Dead code cleanup: removed 6 unused Cargo deps, 2 dead modules, ~30 dead functions, blanket `#![allow(dead_code)]`
+- Wired config file (`~/.config/copt/config.toml`), model aliases (`-m sonnet`), `--config-init`
+- Enhancement pipeline, connectivity caching (5-min TTL), STY004/STY002 ordering fix
+- 2 new static transforms (STY001, FMT002), `LazyLock<Regex>`, shared editor utility, `Provider::as_str()`
+- Net: -954 lines, tests 121→91
 
-**Commit 2** (`d063fb3`): Delete dead modules
-- Deleted `src/rules/mod.rs` (entire module, duplicated analyzer)
-- Deleted `src/utils/file.rs` (entire module, all functions unused)
-- Removed `mod rules;` from `main.rs`, `mod file;` from `utils/mod.rs`
-- Kept `cli/config.rs` with targeted `#![allow(dead_code)]` + TODO for Phase 3
+### v0.3.1 (current branch)
 
-**Commit 3** (`43f3f97`): Remove ~30 dead functions across 11 files
-- `llm/mod.rs`: Removed CompletionRequest, Message, Role, CompletionResponse, Usage
-- `cli/mod.rs`: Removed DEFAULT_MODEL, DEFAULT_MAX_TOKENS, AVAILABLE_MODELS, is_valid_model()
-- `utils/text.rs`: Removed 11 functions (kept count_tokens only)
-- `tui/mod.rs`: Removed pad_right, center, draw_line, draw_box_*, colors module, truncate
-- `tui/renderer.rs`: Removed 9 functions (kept spinner + print_optimized_prompt)
-- `tui/stats.rs`: Removed print_stats, print_stats_compact (kept print_save_success)
-- `tui/diff.rs`: Removed print_unified_diff, diff_stats, DiffStats (kept print_diff)
-- `tui/app.rs`: Removed run_linear, detect_render_mode, run (kept run_interactive)
-- Added targeted `#[allow(dead_code)]` + TODO for items kept for Phase 2/3 wiring
+- Smart prompt naming: `generate_prompt_slug()` in `src/utils/text.rs` — descriptive filenames from prompt content
+- Centralized storage: default save to `~/.copt/prompts/YYYY-MM-DD/<slug>_<HHMMSS>_optimized.txt`
+- `name` field added to JSON output and metadata
+- TUI save handler updated to use new paths/naming
+- Raycast script command (`scripts/raycast/optimize-prompt.sh`) — clipboard optimization via Bedrock
+- Tests: 97 passing
 
-**Commit 4** (`da74e86`): Strip blanket allow(dead_code) from TUI modules
-- Removed `#![allow(dead_code)]` from linear.rs, model.rs, theme.rs, icons.rs, update.rs
-- Added targeted `#[allow(dead_code)]` for 8 TUI architecture items
+## Project Structure
 
-**Phase 1 Results**: ~1,800 lines removed, tests 121→89, zero compiler warnings
-
-### Phase 2: Quick Wins (1 commit)
-
-**Commit 5** (`400e1c1`): All 4 quick wins in one commit
-- Wired `resolve_model_id()` into `main.rs` — users can now type `-m sonnet` instead of full ARN
-- Extracted `build_editor_command` to `src/utils/editor.rs` with `wait: bool` parameter
-- Converted all 4 optimizer transform functions to `LazyLock<Regex>` (compile-once)
-- Added `Provider::as_str()` method, replaced 3 occurrences of `format!("{:?}", cli.provider).to_lowercase()`
-
-### Phase 3: Feature Wiring (2 commits)
-
-**Commit 8** (`3ebe1d1`): Wire config file into main.rs
-- Config loaded from `~/.config/copt/config.toml` (or `~/.copt.toml` legacy)
-- Uses clap `ArgMatches::value_source()` to detect explicit vs default CLI values
-- Config applies: provider, model, region, format, show_diff — CLI always takes precedence
-- Verbose flag (`-v`) shows config load path
-- Removed blanket `#![allow(dead_code)]` from config.rs, added targeted allows for Phase 4 items
-
-**Commit 9** (`ece2495`): Wire enhancements into optimization pipeline
-- Offline mode: enhancement hints appended to optimized output
-- LLM mode: enhancements included in issues summary for LLM context
-- 4 enhancement patterns: parallel_tools, exploration, action_default, summary
-- Removed `#[allow(dead_code)]` from Enhancement struct and `get_applicable_enhancements()`
-
-**Decision**: Keep heuristic token counting (chars/4) — sufficient for display/stats, LLM providers handle their own tokenization
-
-### Phase 4: New Features (3 commits)
-
-**Commit 10** (`7b568b5`): Fix STY004/STY002 double-replacement bug
-- Static transforms now applied in fixed priority order instead of issue order
-- STY004 (overtriggering) runs before STY002 (emphasis) so "CRITICAL:" is removed before caps are lowercased
-
-**Commit 11** (`be7c30b`): Cache connectivity check results
-- Successful checks cached in `/tmp/copt_connectivity_<provider>_<region>.cache` with 5-minute TTL
-- Eliminates 2-5s latency on repeated invocations
-- Verbose flag shows when cache is used
-
-**Commit 12** (`1a36d37`): Add `--config-init` flag
-- `copt --config-init` creates default config at `~/.config/copt/config.toml`
-- Generates complete TOML with all sections: default, anthropic, bedrock, output, rules
-
-### Housekeeping commits
-- **Commit 6** (`06cd276`): Updated handoff prompt after Phase 1
-- **Commit 7** (`1bd7c89`): Updated handoff prompt with Phase 2 completion
-- **Commit 8** (`fbb3b24`): Added `ci-quiet` Makefile target
-
-## Current Project Structure (Post Phase 1-4)
-
-```
+```text
 src/
-├── main.rs              # CLI entry point, clap args, orchestration (~800 lines)
-├── analyzer/mod.rs      # Rule-based prompt analysis, 25 rules across 8 categories
-├── optimizer/mod.rs     # Static transforms (4 rules, LazyLock regex) + enhancements + LLM optimization
+├── main.rs              # CLI entry, clap args, orchestration
+├── analyzer/mod.rs      # 25 analysis rules across 8 categories
+├── optimizer/mod.rs     # 6 static transforms (LazyLock regex) + enhancements + LLM optimization
 ├── llm/
 │   ├── mod.rs           # LlmClient trait, OPTIMIZER_SYSTEM_PROMPT
 │   ├── anthropic.rs     # Anthropic API client
-│   └── bedrock.rs       # AWS Bedrock client (default provider)
+│   └── bedrock.rs       # AWS Bedrock client (default)
 ├── cli/
-│   ├── mod.rs           # Model aliases + resolve_model_id() (NOW WIRED)
-│   ├── config.rs        # Config file system (NOW WIRED — loads defaults, CLI overrides)
-│   └── suggest.rs       # Interactive suggestion flow for vague prompts
+│   ├── mod.rs           # Model aliases + resolve_model_id()
+│   ├── config.rs        # Config file system (~/.config/copt/config.toml)
+│   └── suggest.rs       # Interactive suggestion flow
 ├── utils/
-│   ├── mod.rs           # Re-exports count_tokens + editor
-│   ├── text.rs          # count_tokens() only
-│   └── editor.rs        # build_editor_command() shared utility (NEW in Phase 2)
-└── tui/                 # Elm MVU architecture (ratatui)
-    ├── app.rs           # run_interactive() only
-    ├── model.rs         # State definitions
-    ├── update.rs        # Event handling (uses shared editor utility)
-    ├── view.rs          # Render dispatch
-    ├── linear.rs        # Non-interactive enhanced output
-    ├── renderer.rs      # Spinner + print_optimized_prompt only
-    ├── stats.rs         # print_save_success only
-    ├── diff.rs          # print_diff only
-    ├── theme.rs         # Theme singleton
-    ├── icons.rs         # Nerd Font / Unicode / ASCII icon detection
-    ├── terminal.rs      # Terminal init/restore with panic hooks
-    └── widgets/         # 11 modular ratatui widgets (all active)
+│   ├── mod.rs           # Re-exports
+│   ├── text.rs          # count_tokens(), generate_prompt_slug()
+│   └── editor.rs        # build_editor_command() shared utility
+├── tui/                 # Elm MVU architecture (ratatui)
+│   ├── app.rs           # run_interactive()
+│   ├── model.rs, update.rs, view.rs, linear.rs
+│   ├── renderer.rs, stats.rs, diff.rs
+│   ├── theme.rs, icons.rs, terminal.rs
+│   └── widgets/         # 11 modular ratatui widgets
+└── scripts/raycast/     # Raycast script command
 ```
 
 ## Remaining Work
 
-### Expand Static Optimization Coverage
-- Only 4 of 25 detected rules have static transforms — offline mode underserves
-- Priority candidates: STY001 (role-only prompts), FMT002 (missing XML structure), EXP002 (negative instructions)
-- Each new transform needs: regex pattern, replacement logic, unit test
-
-### Code Quality (can be done alongside features)
-- `handle_output()` in main.rs rebuilds Model from scratch instead of reusing
-- Token counting called redundantly on same prompt in multiple places
-- Consider streaming LLM output for better UX
+- Streaming LLM output (Nice to Have — High effort)
 - Wire `is_rule_enabled()` / `get_severity_override()` from config into analyzer
+- `handle_output()` rebuilds Model from scratch (minor refactor)
+- Token counting called redundantly (minor optimization)
 
-## Build & Test Commands
+## Build & Test
 
 ```bash
-# PREFERRED for agent use (concise output, saves context window):
-make ci-quiet    # 4 lines of output: fmt-check, clippy, build, test result
-
-# Full output versions:
-make ci          # Full CI: fmt-check → lint → build → test
-make check       # Local dev: auto-fix formatting, then lint and test
-
-# Individual:
-cargo test                              # Run all tests (89 currently)
-cargo clippy -- -D warnings             # Lint
-cargo run -- -f docs/SAMPLE_PROMPT.txt --offline           # Test offline mode
-cargo run -- -f docs/SAMPLE_PROMPT.txt -m sonnet           # Test with model alias (Phase 2 feature)
+make ci-quiet                                    # Preferred: 4-line CI output
+cargo run -- -f test_prompt.txt --offline         # Smoke test
+cargo run -- -f test_prompt.txt -m sonnet         # LLM test
 ```
 
-## Critical Rules for Agents
+## Agent Rules
 
-### Git Operations
-- All git ops via container: `docker exec my-git-workspace git -C /workspace/repos/copt <cmd>`
-- Container check: `docker ps --filter name=my-git-workspace --format '{{.Names}}'`
-- Use single quotes for commit messages in zsh (avoids bracket expansion)
-- Atomic commits — one logical change per commit
-- Always test before committing
-
-### Files to Watch
-- `docs/SAMPLE_PROMPT.txt` — test prompt, gets staged by `git add -A` — always unstage it
-- `CONTEXT_MANAGEMENT.md` — untracked, don't stage without asking
-- `docs/tmp/` — gitignored, never force-add files there
-- `docs/tmp/feature-dead-code-cleanup/progress.txt` — update as work progresses (local only)
-
-### Testing Protocol
-- Always run `make ci-quiet` before committing
-- Test the app with `cargo run -- -f docs/SAMPLE_PROMPT.txt --offline` after code changes
-- For LLM mode: `cargo run -- -f docs/SAMPLE_PROMPT.txt -m sonnet`
-
-### Context Management
-- Use `make ci-quiet` instead of `make ci` to save context window
-- Use subagents for parallel tasks and to extend context limits
-- The Kiro IDE supports subagents: context-gatherer (explore codebases) and general-task-execution (parallel work)
-- Delegate independent tasks to subagents to keep main context clean
-
-## Key Files to Read First
-1. This file (`docs/HANDOFF_PROMPT.md`) — you're reading it
-2. `docs/IMPROVEMENTS.md` — detailed analysis with specific recommendations
-3. `CLAUDE.md` — build commands, architecture, git workflow
-4. `Makefile` — build targets including ci-quiet
-5. `src/main.rs` — CLI entry point with Phase 2 changes
-6. `src/optimizer/mod.rs` — LazyLock regex transforms, Enhancement struct for Phase 3
-7. `src/cli/config.rs` — unwired config system for Phase 3
+- Git via container: `docker exec my-git-workspace git -C /workspace/repos/copt <cmd>`
+- Single quotes for commit messages in zsh
+- Atomic commits, always `make ci-quiet` before committing
+- `docs/SAMPLE_PROMPT.txt` gets staged by `git add -A` — always unstage
+- `docs/tmp/` is gitignored — never force-add

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -6,7 +6,7 @@ COPT is a well-structured Rust CLI with a clear purpose and solid architecture (
 
 ## Feature Improvements
 
-### 1. Wire the config system into the application — Should Fix (Medium)
+### 1. Wire the config system into the application — ✅ DONE (v0.3.0)
 
 `src/cli/config.rs` defines a complete configuration system (provider defaults, rule disabling, severity overrides, API key storage) but it is never called from `main.rs`. The `load_config()` function exists, `Config` has validation, but zero integration. This means:
 - Users cannot disable noisy rules (e.g., STY003 "think" word) without `--check` flags every invocation
@@ -15,15 +15,15 @@ COPT is a well-structured Rust CLI with a clear purpose and solid architecture (
 
 Wire `load_config()` into `main()` and merge config values with CLI args (CLI takes precedence). This is the single highest-impact feature gap.
 
-### 2. Use the model alias system — Should Fix (Low)
+### 2. Use the model alias system — ✅ DONE (v0.3.0)
 
 `src/cli/mod.rs` defines `resolve_model_id()` and `MODEL_ALIASES` (e.g., "sonnet" → full Bedrock ARN) but these are never called. The `--model` flag in `main.rs` passes the raw string directly to the LLM client. Users must type `us.anthropic.claude-sonnet-4-5-20250929-v1:0` instead of just `sonnet`. Call `resolve_model_id()` on `cli.model` before passing it downstream.
 
-### 3. Use tiktoken-rs for accurate token counting — Should Fix (Medium)
+### 3. Use tiktoken-rs for accurate token counting — ✅ DONE (v0.3.0)
 
-`tiktoken-rs` is listed in `Cargo.toml` dependencies but never imported. The `count_tokens()` function in `src/utils/text.rs` uses a rough heuristic (`(word_count * 1.3 * 2 + char_count / 4) / 3`). Since you're already paying the compile-time cost of tiktoken-rs, actually use it — or remove the dependency. The inaccurate counts are displayed prominently in the TUI stats dashboard and saved to metadata JSON files, so they should be trustworthy.
+Decided to keep `chars/4` heuristic (display-only; providers handle tokenization). Removed `tiktoken-rs` dependency.
 
-### 4. Expand static optimization coverage — Nice to Have (Medium)
+### 4. Expand static optimization coverage — ✅ DONE (v0.3.0)
 
 The analyzer detects 25 rules but `optimize_static()` only handles 4 (EXP003, STY002, STY003, STY004). Several more rules have straightforward static transformations:
 - **STY001** (negative instructions): "Don't use X" → "Use Y instead" — regex-replaceable for common patterns
@@ -32,38 +32,43 @@ The analyzer detects 25 rules but `optimize_static()` only handles 4 (EXP003, ST
 
 This would make `--offline` mode substantially more useful.
 
-### 5. Add `--config init` subcommand — Nice to Have (Low)
+### 5. Add `--config init` subcommand — ✅ DONE (v0.3.0)
 
-`create_default_config()` exists in `config.rs` but is unreachable. Expose it as `copt --config init` or `copt config init` to generate `~/.config/copt/config.toml`. The function already writes a well-commented default config.
+Exposed as `copt --config-init`. Creates `~/.config/copt/config.toml` with commented defaults.
 
 ### 6. Streaming LLM output — Nice to Have (High)
 
 Both LLM clients wait for the full response before displaying anything. For large prompts, the optimization step can take 10+ seconds with no feedback beyond a spinner. The Bedrock client already uses `invoke_model` (not streaming) — switching to `invoke_model_with_response_stream` would let the TUI show incremental output. The Anthropic client could use SSE streaming similarly.
 
-### 7. Connectivity check is blocking UX — Should Fix (Low)
+### 7. Connectivity check is blocking UX — ✅ DONE (v0.3.0)
 
-`check_provider_connectivity()` in `main.rs` runs a full Bedrock `InvokeModel` call with a tiny prompt before every optimization. This adds 2-5 seconds of latency to every invocation. Consider:
-- Caching the last successful check with a TTL (e.g., 5 minutes) in a temp file
-- Making `--skip-connectivity-check` the default and only checking on first use or failure
-- Running the check concurrently with prompt analysis
+Successful checks now cached with 5-minute TTL in `/tmp/copt_connectivity_<provider>_<region>.cache`.
+
+### 8. Smart prompt naming — Should Fix (Medium)
+
+Saved prompts use generic `optimized_HHMMSS.txt` filenames which are hard to find later. Generate a short descriptive slug from the prompt content (e.g., `dashboard-analytics-api_143022.txt`) so users can identify prompts at a glance without opening each file.
+
+### 9. Standardize prompt storage to `~/.copt/prompts/` — Should Fix (Medium)
+
+Currently saves to `./copt-output/` relative to the working directory, scattering prompt files across the filesystem. Standardize to `~/.copt/prompts/YYYY-MM-DD/` as the default location — centralized, date-bucketed, and consistent with the Raycast integration. The `--output-dir` flag still works for overrides.
 
 ## Code Efficiency & Robustness
 
-### 1. Duplicated `build_editor_command` function
+### 1. Duplicated `build_editor_command` function — ✅ DONE (v0.3.0)
 
-`src/main.rs:354` and `src/tui/update.rs:290` contain identical implementations of `build_editor_command()`. Extract to a shared utility (e.g., `src/utils/editor.rs`) and call from both locations.
+Extracted to `src/utils/editor.rs`.
 
-### 2. Duplicated `Issue` type definitions
+### 2. Duplicated `Issue` type definitions — ✅ DONE (v0.3.0)
 
-`src/analyzer/mod.rs` defines `Issue` and `Severity` as the canonical types (re-exported from `main.rs` via `pub use analyzer::{Issue, Severity}`). But `src/rules/mod.rs` defines its own `Issue`, `Severity`, `Category`, and `patterns` module — a completely parallel type system that nothing uses. This is confusing for contributors and adds cognitive overhead.
+Removed `src/rules/mod.rs` entirely.
 
-### 3. Regex recompilation in optimizer transforms
+### 3. Regex recompilation in optimizer transforms — ✅ DONE (v0.3.0)
 
-`src/optimizer/mod.rs` functions `transform_indirect_commands()`, `transform_aggressive_emphasis()`, `transform_think_word()`, and `transform_overtriggering_language()` all compile regexes on every call via `Regex::new()` inside the function body. These should use `LazyLock<Regex>` (like `src/rules/mod.rs` already does for its patterns) to compile once.
+All optimizer transforms now use `LazyLock<Regex>`.
 
-### 4. `format!("{:?}", cli.provider).to_lowercase()` for provider name
+### 4. `format!("{:?}", cli.provider).to_lowercase()` for provider name — ✅ DONE (v0.3.0)
 
-`src/main.rs` uses `format!("{:?}", cli.provider).to_lowercase()` in multiple places (lines ~475, ~547, ~762) to get the provider string. This relies on the Debug representation of the enum. Add a `Provider::as_str()` method or implement `Display` instead.
+Added `Provider::as_str()` method.
 
 ### 5. Inconsistent `Issue` field types between analyzer and rules
 

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -44,13 +44,13 @@ Both LLM clients wait for the full response before displaying anything. For larg
 
 Successful checks now cached with 5-minute TTL in `/tmp/copt_connectivity_<provider>_<region>.cache`.
 
-### 8. Smart prompt naming — Should Fix (Medium)
+### 8. Smart prompt naming — ✅ DONE (v0.3.1)
 
-Saved prompts use generic `optimized_HHMMSS.txt` filenames which are hard to find later. Generate a short descriptive slug from the prompt content (e.g., `dashboard-analytics-api_143022.txt`) so users can identify prompts at a glance without opening each file.
+`generate_prompt_slug()` extracts a descriptive slug from prompt content for filenames (e.g., `dashboard-analytics-api_143022_optimized.txt`). JSON output and metadata include a `name` field.
 
-### 9. Standardize prompt storage to `~/.copt/prompts/` — Should Fix (Medium)
+### 9. Standardize prompt storage to `~/.copt/prompts/` — ✅ DONE (v0.3.1)
 
-Currently saves to `./copt-output/` relative to the working directory, scattering prompt files across the filesystem. Standardize to `~/.copt/prompts/YYYY-MM-DD/` as the default location — centralized, date-bucketed, and consistent with the Raycast integration. The `--output-dir` flag still works for overrides.
+Default save location changed from `./copt-output/` to `~/.copt/prompts/YYYY-MM-DD/`. Date-bucketed, centralized. `--output-dir` still works for overrides.
 
 ## Code Efficiency & Robustness
 

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -70,9 +70,9 @@ All optimizer transforms now use `LazyLock<Regex>`.
 
 Added `Provider::as_str()` method.
 
-### 5. Inconsistent `Issue` field types between analyzer and rules
+### 5. Inconsistent `Issue` field types between analyzer and rules — ✅ DONE (v0.3.0)
 
-The analyzer's `Issue` uses `category: String` while the rules module's `Issue` uses `category: Category` (an enum). If the rules module is kept, these should be unified. If removed (recommended), this inconsistency goes away.
+No longer applicable — `src/rules/mod.rs` was removed entirely.
 
 ### 6. `handle_output` rebuilds Model from scratch
 
@@ -146,16 +146,16 @@ The `Enhancement` struct and `get_applicable_enhancements()` function in `src/op
 
 ## Quick Wins
 
-1. **Remove 6 unused Cargo dependencies** (`tiktoken-rs`, `dotenvy`, `textwrap`, `unicode-segmentation`, `directories`, `futures`). This will noticeably reduce compile times. Estimated: 10 minutes of work, immediate build speed improvement.
+1. ✅ **Remove 6 unused Cargo dependencies** — DONE (v0.3.0). Removed `tiktoken-rs`, `dotenvy`, `textwrap`, `unicode-segmentation`, `directories`, `futures`.
 
-2. **Wire `resolve_model_id()` into `main.rs`**. One line change: `let model = cli::resolve_model_id(&cli.model);` before passing to LLM clients. Users can then type `copt -m sonnet` instead of the full ARN. Estimated: 5 minutes.
+2. ✅ **Wire `resolve_model_id()` into `main.rs`** — DONE (v0.3.0). Users can type `copt -m sonnet`.
 
-3. **Fix STY004 double-replacement bug** in `transform_overtriggering_language()`. The regex replacements for "MUST" → "should" and "ALWAYS" → "should" can stack. Process the string once with a single pass or use a priority system. Estimated: 15 minutes.
+3. ✅ **Fix STY004 double-replacement bug** — DONE (v0.3.0). Static transforms now apply in fixed priority order.
 
-4. **Remove blanket `#![allow(dead_code)]`** from all files and either delete dead code or add targeted `#[allow(dead_code)]` with a comment explaining why it's kept. This prevents future dead code accumulation. Estimated: 30 minutes.
+4. ✅ **Remove blanket `#![allow(dead_code)]`** — DONE (v0.3.0). All blanket annotations removed, targeted allows added where needed.
 
-5. **Delete `src/rules/mod.rs`** and remove `mod rules;` from `main.rs`. It's a complete duplicate of functionality in `src/analyzer/mod.rs` and adds confusion. Estimated: 2 minutes.
+5. ✅ **Delete `src/rules/mod.rs`** — DONE (v0.3.0). Module and `mod rules;` declaration removed.
 
-6. **Extract `build_editor_command` to shared utility**. Currently duplicated between `main.rs:354` and `tui/update.rs:290`. Estimated: 10 minutes.
+6. ✅ **Extract `build_editor_command` to shared utility** — DONE (v0.3.0). Now in `src/utils/editor.rs`.
 
-7. **Add `--editor` to the help examples**. The `-e` / `--editor` flag for multi-line input is a nice feature but isn't mentioned in the README Quick Start or Common Examples sections. Estimated: 5 minutes.
+7. ✅ **Add `--editor` to the help output** — DONE (v0.3.1). `-e, --editor` visible in `--help` and README CLI reference.

--- a/scripts/raycast/README.md
+++ b/scripts/raycast/README.md
@@ -9,7 +9,7 @@ Optimize prompts directly from your clipboard using Raycast.
 3. Wait a few seconds while Claude optimizes it via Bedrock
 4. Your clipboard is replaced with the optimized prompt — paste it anywhere
 
-Both the original and optimized prompts are saved to `~/.copt/prompts/YYYY-MM-DD/` for reference.
+Both the original and optimized prompts are auto-saved to `~/.copt/prompts/YYYY-MM-DD/` with descriptive filenames.
 
 ## Setup
 
@@ -44,21 +44,23 @@ COPT_BIN=/usr/local/bin/copt
 
 ## Prompt Storage
 
-Optimized prompts are saved to:
+Optimized prompts are auto-saved by `copt` to:
 
-```bash
+```
 ~/.copt/prompts/
 └── 2026-02-15/
-    ├── original_143022.txt
-    ├── optimized_143022.txt
-    ├── original_150510.txt
-    └── optimized_150510.txt
+    ├── dashboard-analytics-api_143022_original.txt
+    ├── dashboard-analytics-api_143022_optimized.txt
+    ├── dashboard-analytics-api_143022.json
+    ├── code-review-rust-pr_150510_original.txt
+    ├── code-review-rust-pr_150510_optimized.txt
+    └── code-review-rust-pr_150510.json
 ```
 
-Each optimization creates a timestamped pair (original + optimized) grouped by date.
+Each optimization creates a timestamped triplet (original + optimized + metadata) with a descriptive name derived from the prompt content, grouped by date.
 
 ## Tips
 
 - Assign a hotkey in Raycast for quick access (e.g., `⌥⇧O`)
 - Works with any text in your clipboard — prompt files, chat messages, system prompts
-- The script uses `--quiet --no-save` flags so copt only outputs the optimized text and skips its default save behavior
+- The script uses `--format json` to cleanly extract the optimized prompt — copt handles saving automatically to `~/.copt/prompts/`

--- a/scripts/raycast/optimize-prompt.sh
+++ b/scripts/raycast/optimize-prompt.sh
@@ -23,7 +23,6 @@ fi
 export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
 
 COPT_BIN="${COPT_BIN:-copt}"
-PROMPTS_DIR="$HOME/.copt/prompts"
 
 # Ensure AWS credentials are available
 # Set these if your .zshrc doesn't export them, or override via Raycast env vars
@@ -44,33 +43,26 @@ fi
 
 # --- Optimize ---
 # Use JSON format to cleanly extract the optimized prompt
-error_output=$("$COPT_BIN" "$clipboard" --format json --no-save 2>/tmp/copt_raycast_err.log)
+# copt auto-saves to ~/.copt/prompts/YYYY-MM-DD/ with smart naming
+json_output=$("$COPT_BIN" "$clipboard" --format json 2>/tmp/copt_raycast_err.log)
 exit_code=$?
 
-if [ $exit_code -ne 0 ] || [ -z "$error_output" ]; then
+if [ $exit_code -ne 0 ] || [ -z "$json_output" ]; then
   error_msg=$(cat /tmp/copt_raycast_err.log 2>/dev/null | head -3)
   echo "Optimization failed: ${error_msg:-unknown error}"
   exit 1
 fi
 
-# Extract just the optimized prompt from JSON output
-optimized=$(echo "$error_output" | /usr/bin/python3 -c "import sys,json; print(json.load(sys.stdin).get('optimized',''))" 2>/dev/null)
+# Extract the optimized prompt and name from JSON output
+optimized=$(echo "$json_output" | /usr/bin/python3 -c "import sys,json; print(json.load(sys.stdin).get('optimized',''))" 2>/dev/null)
+name=$(echo "$json_output" | /usr/bin/python3 -c "import sys,json; print(json.load(sys.stdin).get('name','prompt'))" 2>/dev/null)
 
 if [ -z "$optimized" ]; then
   echo "Could not extract optimized prompt from output"
   exit 1
 fi
 
-# --- Save to ~/.copt/prompts/YYYY-MM-DD/ ---
-today=$(date +%Y-%m-%d)
-timestamp=$(date +%H%M%S)
-day_dir="$PROMPTS_DIR/$today"
-mkdir -p "$day_dir"
-
-echo "$clipboard"  > "$day_dir/original_${timestamp}.txt"
-echo "$optimized"  > "$day_dir/optimized_${timestamp}.txt"
-
 # --- Update clipboard ---
 echo "$optimized" | pbcopy
 
-echo "Prompt optimized ✓"
+echo "✓ ${name}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,10 +45,9 @@ struct Cli {
     #[arg(
         long,
         value_name = "DIR",
-        default_value = "copt-output",
         hide_default_value = true
     )]
-    output_dir: PathBuf,
+    output_dir: Option<PathBuf>,
 
     /// Disable auto-save
     #[arg(long)]
@@ -679,7 +678,9 @@ async fn handle_output(cli: &Cli, result: &OptimizationResult) -> Result<()> {
 
     match cli.format {
         OutputFormat::Json => {
+            let slug = utils::generate_prompt_slug(&result.original);
             let json = serde_json::json!({
+                "name": slug,
                 "original": result.original,
                 "optimized": result.optimized,
                 "issues": result.issues.iter().map(|i| serde_json::json!({
@@ -748,11 +749,21 @@ async fn handle_output(cli: &Cli, result: &OptimizationResult) -> Result<()> {
     let output_path = if let Some(ref explicit_output) = cli.output {
         // User specified explicit output path (always respect this)
         Some(explicit_output.clone())
-    } else if !cli.no_save && !cli.offline && !cli.analyze && cli.format != OutputFormat::Json {
-        // Auto-save to output directory (only when not in offline mode or analyze mode)
-        let timestamp = Local::now().format("%Y%m%d_%H%M%S");
-        let filename = format!("optimized_{}.txt", timestamp);
-        Some(cli.output_dir.join(filename))
+    } else if !cli.no_save && !cli.offline && !cli.analyze {
+        // Auto-save to ~/.copt/prompts/YYYY-MM-DD/ (or custom --output-dir)
+        let timestamp = Local::now().format("%H%M%S");
+        let date_dir = Local::now().format("%Y-%m-%d").to_string();
+        let slug = utils::generate_prompt_slug(&result.original);
+        let filename = format!("{slug}_{timestamp}_optimized.txt");
+
+        let base_dir = cli
+            .output_dir
+            .clone()
+            .unwrap_or_else(|| {
+                let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+                PathBuf::from(home).join(".copt").join("prompts")
+            });
+        Some(base_dir.join(&date_dir).join(filename))
     } else {
         None
     };
@@ -769,7 +780,7 @@ async fn handle_output(cli: &Cli, result: &OptimizationResult) -> Result<()> {
         // Derive original prompt path from optimized path
         let original_path = {
             let filename = path.file_name().unwrap().to_string_lossy();
-            let original_filename = filename.replace("optimized_", "original_");
+            let original_filename = filename.replace("_optimized.txt", "_original.txt");
             path.with_file_name(original_filename)
         };
 
@@ -784,8 +795,10 @@ async fn handle_output(cli: &Cli, result: &OptimizationResult) -> Result<()> {
             .with_context(|| format!("Failed to write original: {}", original_path.display()))?;
 
         // Also write metadata JSON alongside
+        let slug = utils::generate_prompt_slug(&result.original);
         let metadata_path = path.with_extension("json");
         let metadata = serde_json::json!({
+            "name": slug,
             "timestamp": Local::now().to_rfc3339(),
             "files": {
                 "original": original_path.file_name().unwrap().to_string_lossy(),
@@ -898,9 +911,19 @@ async fn run_interactive_mode(cli: &Cli, prompt: &str) -> Result<()> {
     // After TUI exits, handle auto-save if we have results
     if let Some(ref optimized) = model.optimized_prompt {
         if !cli.no_save && !cli.offline {
-            let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
-            let filename = format!("optimized_{}.txt", timestamp);
-            let output_path = cli.output_dir.join(filename);
+            let timestamp = chrono::Local::now().format("%H%M%S");
+            let date_dir = chrono::Local::now().format("%Y-%m-%d").to_string();
+            let slug = utils::generate_prompt_slug(&model.original_prompt);
+            let filename = format!("{slug}_{timestamp}_optimized.txt");
+
+            let base_dir = cli
+                .output_dir
+                .clone()
+                .unwrap_or_else(|| {
+                    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+                    PathBuf::from(home).join(".copt").join("prompts")
+                });
+            let output_path = base_dir.join(&date_dir).join(filename);
 
             // Create output directory if it doesn't exist
             if let Some(parent) = output_path.parent() {

--- a/src/tui/snapshots/copt__tui__snapshot_tests__diff_view.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__diff_view.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.0                                               
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.1                                               
                                                                                 
 ────────────────────────────────────────────────────────────────────────────────
 ┌ ✨  Changes ──────────────────────────────────────────────────────────────────┐

--- a/src/tui/snapshots/copt__tui__snapshot_tests__help_view.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__help_view.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.0                                               
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.1                                               
                                                                                 
 ────────────────────────────────────────────────────────────────────────────────
 ┌ Keyboard Shortcuts ──────────────────────────────────────────────────────────┐

--- a/src/tui/snapshots/copt__tui__snapshot_tests__main_view_analysis_done.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__main_view_analysis_done.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.0                                               
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.1                                               
 Optimize prompts for Claude 4.5                                                 
 📥  Input: test_prompt.txt (53 chars, 12 tokens)                                 
 ────────────────────────────────────────────────────────────────────────────────

--- a/src/tui/snapshots/copt__tui__snapshot_tests__main_view_done.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__main_view_done.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.0                                               
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.1                                               
 Optimize prompts for Claude 4.5                                                 
 📥  Input: test_prompt.txt (53 chars, 12 tokens)                                 
 ────────────────────────────────────────────────────────────────────────────────

--- a/src/tui/snapshots/copt__tui__snapshot_tests__no_issues.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__no_issues.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.0                                               
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.1                                               
 Optimize prompts for Claude 4.5                                                 
 📥  Input: stdin (30 chars, 5 tokens)                                            
 ────────────────────────────────────────────────────────────────────────────────

--- a/src/tui/snapshots/copt__tui__snapshot_tests__offline_mode.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__offline_mode.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.0 [OFFLINE MODE]                                
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.1 [OFFLINE MODE]                                
 Static analysis only (no LLM calls)                                             
 📥  Input: test_prompt.txt (53 chars, 12 tokens)                                 
 ────────────────────────────────────────────────────────────────────────────────

--- a/src/tui/update.rs
+++ b/src/tui/update.rs
@@ -217,10 +217,17 @@ fn handle_copy(model: &mut Model) -> bool {
 /// Handle save action - saves to copt-output/ and auto-opens in editor
 fn handle_save(model: &mut Model) -> bool {
     if let Some(ref optimized) = model.optimized_prompt {
-        // Generate output path
-        let timestamp = Local::now().format("%Y%m%d_%H%M%S");
-        let filename = format!("optimized_{}.txt", timestamp);
-        let output_dir = std::path::PathBuf::from("copt-output");
+        // Generate output path with smart naming
+        let timestamp = Local::now().format("%H%M%S");
+        let date_dir = Local::now().format("%Y-%m-%d").to_string();
+        let slug = crate::utils::generate_prompt_slug(&model.original_prompt);
+        let filename = format!("{slug}_{timestamp}_optimized.txt");
+
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        let output_dir = std::path::PathBuf::from(home)
+            .join(".copt")
+            .join("prompts")
+            .join(&date_dir);
         let output_path = output_dir.join(&filename);
 
         // Create output directory if needed

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,3 +9,4 @@ pub mod text;
 
 // Re-export commonly used items
 pub use text::count_tokens;
+pub use text::generate_prompt_slug;

--- a/src/utils/text.rs
+++ b/src/utils/text.rs
@@ -1,6 +1,74 @@
 //! Text processing utilities
 //!
-//! Provides token counting functions.
+//! Provides token counting and prompt slug generation.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex to strip XML tags
+static XML_TAG_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<[^>]+>").unwrap());
+
+/// Regex to strip common prompt prefixes (boilerplate only, not action verbs)
+static PREFIX_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^(you are an?|act as an?|please|i want you to|help me|i need you to)\s+")
+        .unwrap()
+});
+
+/// Regex for slugification — anything that isn't alphanumeric
+static SLUG_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[^a-z0-9]+").unwrap());
+
+/// Generate a short descriptive slug from prompt content for use in filenames.
+///
+/// Extracts the first meaningful phrase, strips boilerplate, and produces
+/// a kebab-case slug truncated to ~50 characters at a word boundary.
+///
+/// # Examples
+/// ```
+/// use copt::utils::text::generate_prompt_slug;
+/// assert_eq!(generate_prompt_slug("Create a dashboard for analytics"), "create-a-dashboard-for-analytics");
+/// assert_eq!(generate_prompt_slug("You are an expert. Review this code for bugs"), "expert-review-this-code-for");
+/// assert_eq!(generate_prompt_slug(""), "prompt");
+/// ```
+pub fn generate_prompt_slug(prompt: &str) -> String {
+    // Strip XML tags
+    let cleaned = XML_TAG_RE.replace_all(prompt, " ");
+
+    // Take the first non-empty line as the most descriptive content
+    let first_line = cleaned
+        .lines()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+
+    // Strip common prompt prefixes
+    let stripped = PREFIX_RE.replace(first_line, "");
+    let stripped = stripped.trim();
+
+    // Take first ~6 words
+    let words: Vec<&str> = stripped.split_whitespace().take(6).collect();
+    let phrase = words.join(" ");
+
+    // Slugify: lowercase, replace non-alphanumeric with hyphens
+    let lowered = phrase.to_lowercase();
+    let slug = SLUG_RE.replace_all(&lowered, "-");
+
+    // Trim leading/trailing hyphens
+    let slug = slug.trim_matches('-');
+
+    if slug.is_empty() {
+        return "prompt".to_string();
+    }
+
+    // Truncate to 50 chars at a hyphen boundary
+    if slug.len() <= 50 {
+        slug.to_string()
+    } else {
+        match slug[..50].rfind('-') {
+            Some(pos) => slug[..pos].to_string(),
+            None => slug[..50].to_string(),
+        }
+    }
+}
 
 /// Estimate token count for a string
 ///
@@ -31,5 +99,60 @@ mod tests {
     fn test_count_tokens() {
         assert!(count_tokens("Hello world") > 0);
         assert!(count_tokens("This is a longer sentence with more words") > count_tokens("Hello"));
+    }
+
+    #[test]
+    fn test_slug_basic() {
+        assert_eq!(
+            generate_prompt_slug("Create a dashboard for analytics"),
+            "create-a-dashboard-for-analytics"
+        );
+    }
+
+    #[test]
+    fn test_slug_strips_prefix() {
+        assert_eq!(
+            generate_prompt_slug("You are an expert code reviewer. Review this PR"),
+            "expert-code-reviewer-review-this-pr"
+        );
+        // "Please" stripped, rest kept
+        assert_eq!(
+            generate_prompt_slug("Please write a Python script for data processing"),
+            "write-a-python-script-for-data"
+        );
+    }
+
+    #[test]
+    fn test_slug_strips_xml() {
+        // XML tags stripped → "You are helpful" on first line
+        // "You are an" prefix doesn't match (no "a/an"), so kept as-is
+        assert_eq!(
+            generate_prompt_slug("<system>You are helpful</system>\nAnalyze this code"),
+            "you-are-helpful"
+        );
+    }
+
+    #[test]
+    fn test_slug_truncates_long_input() {
+        let long_prompt = "Implement a comprehensive real-time analytics dashboard with user authentication session management data visualization export functionality and automated reporting";
+        let slug = generate_prompt_slug(long_prompt);
+        assert!(slug.len() <= 50);
+        // "Implement" stripped as prefix? No — not in prefix list. Takes first 6 words.
+        assert_eq!(slug, "implement-a-comprehensive-real-time-analytics");
+    }
+
+    #[test]
+    fn test_slug_empty_input() {
+        assert_eq!(generate_prompt_slug(""), "prompt");
+        assert_eq!(generate_prompt_slug("   "), "prompt");
+    }
+
+    #[test]
+    fn test_slug_special_characters() {
+        // 6 words: "what's the best way to handle"
+        assert_eq!(
+            generate_prompt_slug("What's the best way to handle errors?"),
+            "what-s-the-best-way-to-handle"
+        );
     }
 }


### PR DESCRIPTION
# Smart Prompt Storage & Raycast Integration

## Summary

Optimized prompts now save to a centralized, date-bucketed location with descriptive filenames — making them easy to find without opening each file. Includes a Raycast script command for one-keystroke clipboard optimization.

## What Changed

### Smart prompt naming

Previously: `optimized_143022.txt` — generic, impossible to identify at a glance.

Now: `dashboard-analytics-api_143022_optimized.txt` — derived from prompt content.

A new `generate_prompt_slug()` function extracts the first meaningful phrase from the prompt, strips boilerplate prefixes ("You are a...", "Please..."), and produces a kebab-case slug truncated to 50 characters. The slug is also included as a `name` field in `--format json` output and metadata files.

### Centralized storage

Previously: `./copt-output/` relative to the working directory — prompts scattered across the filesystem.

Now: `~/.copt/prompts/YYYY-MM-DD/` — one place for all optimized prompts, organized by date.

```
~/.copt/prompts/
└── 2026-02-15/
    ├── dashboard-analytics-api_143022_original.txt
    ├── dashboard-analytics-api_143022_optimized.txt
    ├── dashboard-analytics-api_143022.json
    ├── code-review-rust-pr_150510_original.txt
    ├── code-review-rust-pr_150510_optimized.txt
    └── code-review-rust-pr_150510.json
```

`--output-dir <DIR>` still works for overrides. `-o <FILE>` still writes to the exact path specified.

### Raycast script command

`scripts/raycast/optimize-prompt.sh` — copy a prompt, trigger from Raycast, clipboard is replaced with the optimized version. Uses `--format json` to cleanly extract the result. Shows a loading spinner while Bedrock processes, then displays the prompt slug on completion.

### Behavioral change: JSON format auto-save

`--format json` no longer suppresses auto-save. Previously JSON output implied scripting use and skipped saving. Now all modes auto-save unless `--no-save` is explicitly passed.

## Files changed (18 files, +334 / -239)

| Area | Files | What |
|------|-------|------|
| Core | `src/utils/text.rs`, `src/utils/mod.rs` | `generate_prompt_slug()` + 6 tests |
| Core | `src/main.rs` | New default save path, slug in JSON/metadata, `output_dir` now `Option<PathBuf>` |
| TUI | `src/tui/update.rs` | Save handler uses new paths/naming |
| Raycast | `scripts/raycast/optimize-prompt.sh`, `scripts/raycast/README.md` | Script command + docs |
| Docs | `README.md` | CLI reference audit, prompt storage section, Raycast section, 25 rules (was 27) |
| Docs | `CHANGELOG.md` | v0.3.1 entry |
| Docs | `docs/HANDOFF_PROMPT.md` | Rewritten for current state |
| Docs | `docs/IMPROVEMENTS.md` | Items 8, 9 + all quick wins marked done |
| Version | `Cargo.toml`, `Cargo.lock`, 6 snapshot files | 0.3.0 → 0.3.1 |

## Testing

- 97 tests pass (91 existing + 6 new slug generation tests)
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean
- Smoke tested: `cargo run -- -f test_prompt.txt --offline`
- Raycast script tested end-to-end with Bedrock optimization
