### PR TITLE
Feature/bedrock api keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to `copt` (Claude Prompt Optimizer) will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-02-15
+
+### Added
+
+- **Bedrock API Key authentication**: New `BedrockApiKeyClient` uses Bearer token auth via the Converse API — no AWS CLI, IAM roles, or credential chain setup needed
+- **API key resolution**: `--bedrock-api-key` CLI flag → `AWS_BEARER_TOKEN_BEDROCK` env var → `api_key` in config.toml → SigV4 fallback
+- **Improved `--config-init`**: Generates a commented config template with clear API key guidance
+
+### Changed
+
+- **Connectivity check**: Now shows auth method ("API key" vs "AWS credentials") in status output
+- **Error messages**: Credential failures now suggest Bedrock API keys as the simplest fix
+- **Config simplification**: Removed `api_key_env` from `BedrockConfig` (confusing indirection)
+
+### Technical
+
+- `BedrockApiKeyClient` uses `reqwest` + Converse API (`/model/{id}/converse`) with `Authorization: Bearer` header
+- Shared `get_bedrock_model_id()` extracted from `BedrockClient` method for both clients
+- AWS SDK deps retained for backward-compatible SigV4 fallback
+- Test suite: 97 → 101 (4 new: client creation, provider name, request/response serialization)
+
+---
+
 ## [0.3.1] - 2026-02-15
 
 ### Added
@@ -317,7 +340,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/praveenc/copt/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/praveenc/copt/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/praveenc/copt/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/praveenc/copt/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/praveenc/copt/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/praveenc/copt/compare/v0.2.2...v0.2.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "copt"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "copt"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Praveen Chamarthi"]
 description = "Claude Prompt Optimizer - A beautiful CLI tool to optimize prompts for Claude 4.5 family of models"

--- a/README.md
+++ b/README.md
@@ -50,14 +50,17 @@ cargo install --git https://github.com/praveenc/copt
 ### 1. Set Up Credentials
 
 ```bash
-# AWS Bedrock (default)
-export AWS_ACCESS_KEY_ID="..."
-export AWS_SECRET_ACCESS_KEY="..."
-export AWS_REGION="us-west-2"
+# Bedrock API key (recommended — simplest setup)
+export AWS_BEARER_TOKEN_BEDROCK="your-bedrock-api-key"
 
 # Or Anthropic API
 export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Or AWS credential chain (SigV4 fallback — no API key needed)
+# Uses ~/.aws/credentials, AWS_PROFILE, IAM roles, SSO, etc.
 ```
+
+To generate a Bedrock API key: Bedrock console → API keys → Generate long-term key (up to 1 year).
 
 ### 2. Create a Config File (optional)
 
@@ -65,12 +68,18 @@ export ANTHROPIC_API_KEY="sk-ant-..."
 copt --config-init    # Creates ~/.config/copt/config.toml
 ```
 
-Edit the config to set your preferred defaults:
+Edit the config to set your preferred defaults (including API key):
 
 ```toml
+[default]
 provider = "bedrock"
 model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+[bedrock]
 region = "us-west-2"
+api_key = "your-bedrock-api-key"   # or use AWS_BEARER_TOKEN_BEDROCK env var
+
+[output]
 format = "pretty"
 show_diff = false
 ```

--- a/docs/HANDOFF_PROMPT.md
+++ b/docs/HANDOFF_PROMPT.md
@@ -57,6 +57,7 @@ src/
 
 ## Remaining Work
 
+- **Bedrock API Key auth** (v0.3.2, in progress) — Replace AWS SDK SigV4 with Bearer token auth using Bedrock API keys. Drop `aws-config`, `aws-sdk-bedrockruntime`, `aws-credential-types` deps. Use `reqwest` HTTP calls with `Authorization: Bearer <key>`. Fall back to SigV4 when no API key present.
 - Streaming LLM output (Nice to Have — High effort)
 - Wire `is_rule_enabled()` / `get_severity_override()` from config into analyzer
 - `handle_output()` rebuilds Model from scratch (minor refactor)

--- a/docs/HANDOFF_PROMPT.md
+++ b/docs/HANDOFF_PROMPT.md
@@ -2,30 +2,35 @@
 
 ## Context
 
-**COPT** (Claude Prompt Optimizer) is a Rust CLI tool that analyzes and rewrites prompts for Claude 4.5 models. The project is at v0.3.1, functional, and in active use.
+**COPT** (Claude Prompt Optimizer) is a Rust CLI tool that analyzes and rewrites prompts for Claude 4.5 models. The project is at v0.3.2, functional, and in active use.
 
 ## Current State
 
-Branch: `feature/smart-prompt-storage` (based on `main` at v0.3.0)
+Branch: `feature/bedrock-api-keys` (based on `main` at v0.3.1)
+
+### v0.3.2 (current branch, not yet merged)
+
+- **Bedrock API Key auth**: `BedrockApiKeyClient` in `src/llm/bedrock.rs` — uses `reqwest` + Converse API with `Authorization: Bearer <key>` header
+- Key resolution order: `--bedrock-api-key` CLI flag → `AWS_BEARER_TOKEN_BEDROCK` env var → `api_key` in `~/.config/copt/config.toml` → SigV4 fallback
+- Connectivity check shows auth method ("API key" vs "AWS credentials")
+- `--config-init` generates hand-crafted template with comments and API key guidance
+- Error messages suggest API keys as simplest fix for credential issues
+- AWS SDK deps kept for backward-compatible SigV4 fallback
+- Shared `get_bedrock_model_id()` function (extracted from `BedrockClient` method)
+- Tests: 101 passing (4 new: client creation, provider name, request/response serialization)
+
+### v0.3.1 (merged to main)
+
+- Smart prompt naming: `generate_prompt_slug()` in `src/utils/text.rs`
+- Centralized storage: `~/.copt/prompts/YYYY-MM-DD/<slug>_<HHMMSS>_optimized.txt`
+- Raycast script command (`scripts/raycast/optimize-prompt.sh`)
+- `name` field in JSON output and metadata
 
 ### v0.3.0 (merged to main)
 
-All improvements from `docs/IMPROVEMENTS.md` Phases 1-4 are complete:
-
-- Dead code cleanup: removed 6 unused Cargo deps, 2 dead modules, ~30 dead functions, blanket `#![allow(dead_code)]`
-- Wired config file (`~/.config/copt/config.toml`), model aliases (`-m sonnet`), `--config-init`
-- Enhancement pipeline, connectivity caching (5-min TTL), STY004/STY002 ordering fix
-- 2 new static transforms (STY001, FMT002), `LazyLock<Regex>`, shared editor utility, `Provider::as_str()`
-- Net: -954 lines, tests 121→91
-
-### v0.3.1 (current branch)
-
-- Smart prompt naming: `generate_prompt_slug()` in `src/utils/text.rs` — descriptive filenames from prompt content
-- Centralized storage: default save to `~/.copt/prompts/YYYY-MM-DD/<slug>_<HHMMSS>_optimized.txt`
-- `name` field added to JSON output and metadata
-- TUI save handler updated to use new paths/naming
-- Raycast script command (`scripts/raycast/optimize-prompt.sh`) — clipboard optimization via Bedrock
-- Tests: 97 passing
+- Dead code cleanup, config file, model aliases, `--config-init`
+- Enhancement pipeline, connectivity caching, STY004/STY002 fix
+- 2 new static transforms (STY001, FMT002), `LazyLock<Regex>`
 
 ## Project Structure
 
@@ -33,11 +38,11 @@ All improvements from `docs/IMPROVEMENTS.md` Phases 1-4 are complete:
 src/
 ├── main.rs              # CLI entry, clap args, orchestration
 ├── analyzer/mod.rs      # 25 analysis rules across 8 categories
-├── optimizer/mod.rs     # 6 static transforms (LazyLock regex) + enhancements + LLM optimization
+├── optimizer/mod.rs     # 6 static transforms + enhancements + LLM optimization
 ├── llm/
 │   ├── mod.rs           # LlmClient trait, OPTIMIZER_SYSTEM_PROMPT
-│   ├── anthropic.rs     # Anthropic API client
-│   └── bedrock.rs       # AWS Bedrock client (default)
+│   ├── anthropic.rs     # Anthropic API client (reqwest + x-api-key header)
+│   └── bedrock.rs       # BedrockClient (SigV4/AWS SDK) + BedrockApiKeyClient (Bearer token/Converse API)
 ├── cli/
 │   ├── mod.rs           # Model aliases + resolve_model_id()
 │   ├── config.rs        # Config file system (~/.config/copt/config.toml)
@@ -57,18 +62,19 @@ src/
 
 ## Remaining Work
 
-- **Bedrock API Key auth** (v0.3.2, in progress) — Replace AWS SDK SigV4 with Bearer token auth using Bedrock API keys. Drop `aws-config`, `aws-sdk-bedrockruntime`, `aws-credential-types` deps. Use `reqwest` HTTP calls with `Authorization: Bearer <key>`. Fall back to SigV4 when no API key present.
+- Version bump to v0.3.2 + CHANGELOG entry (do before merging)
 - Streaming LLM output (Nice to Have — High effort)
 - Wire `is_rule_enabled()` / `get_severity_override()` from config into analyzer
 - `handle_output()` rebuilds Model from scratch (minor refactor)
 - Token counting called redundantly (minor optimization)
+- Consider gating AWS SDK deps behind a cargo feature flag (future)
 
 ## Build & Test
 
 ```bash
 make ci-quiet                                    # Preferred: 4-line CI output
 cargo run -- -f test_prompt.txt --offline         # Smoke test
-cargo run -- -f test_prompt.txt -m sonnet         # LLM test
+cargo run -- -f test_prompt.txt -m sonnet         # LLM test (needs API key or AWS creds)
 ```
 
 ## Agent Rules
@@ -76,5 +82,5 @@ cargo run -- -f test_prompt.txt -m sonnet         # LLM test
 - Git via container: `docker exec my-git-workspace git -C /workspace/repos/copt <cmd>`
 - Single quotes for commit messages in zsh
 - Atomic commits, always `make ci-quiet` before committing
-- `docs/SAMPLE_PROMPT.txt` gets staged by `git add -A` — always unstage
 - `docs/tmp/` is gitignored — never force-add
+- Always run `cargo fmt` before committing

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -52,16 +52,17 @@ Successful checks now cached with 5-minute TTL in `/tmp/copt_connectivity_<provi
 
 Default save location changed from `./copt-output/` to `~/.copt/prompts/YYYY-MM-DD/`. Date-bucketed, centralized. `--output-dir` still works for overrides.
 
-### 10. Bedrock API Key authentication
+### 10. Bedrock API Key authentication — ✅ DONE (v0.3.2)
 
 Replace the current AWS SDK SigV4 credential chain (requires AWS CLI, `aws configure`, IAM roles, `AWS_PROFILE`, etc.) with Bedrock API Key Bearer token authentication. Long-term keys support up to 1-year expiry — effectively "set and forget" for a developer CLI tool.
 
-Key changes:
-- Replace `aws-sdk-bedrockruntime` + `aws-config` with direct `reqwest` HTTP calls using `Authorization: Bearer <key>` header
-- Read key from `AWS_BEARER_TOKEN_BEDROCK` env var, `--bedrock-api-key` CLI flag, or `~/.config/copt/config.toml`
-- Drop 3 heavy AWS SDK crates → faster compile times, smaller binary
-- Fall back to existing SigV4 credential chain when no API key is present (backward compatible)
-- Update config file, Raycast script, README, error messages
+Changes:
+- `BedrockApiKeyClient` using `reqwest` + Converse API with `Authorization: Bearer <key>` header
+- Key resolution: `--bedrock-api-key` CLI flag → `AWS_BEARER_TOKEN_BEDROCK` env var → `api_key` in config.toml → SigV4 fallback
+- Connectivity check shows auth method ("API key" vs "AWS credentials")
+- `--config-init` generates commented template with API key guidance
+- Error messages suggest API keys as simplest fix for credential issues
+- AWS SDK deps kept for backward-compatible SigV4 fallback
 
 ## Code Efficiency & Robustness
 

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -52,6 +52,17 @@ Successful checks now cached with 5-minute TTL in `/tmp/copt_connectivity_<provi
 
 Default save location changed from `./copt-output/` to `~/.copt/prompts/YYYY-MM-DD/`. Date-bucketed, centralized. `--output-dir` still works for overrides.
 
+### 10. Bedrock API Key authentication
+
+Replace the current AWS SDK SigV4 credential chain (requires AWS CLI, `aws configure`, IAM roles, `AWS_PROFILE`, etc.) with Bedrock API Key Bearer token authentication. Long-term keys support up to 1-year expiry — effectively "set and forget" for a developer CLI tool.
+
+Key changes:
+- Replace `aws-sdk-bedrockruntime` + `aws-config` with direct `reqwest` HTTP calls using `Authorization: Bearer <key>` header
+- Read key from `AWS_BEARER_TOKEN_BEDROCK` env var, `--bedrock-api-key` CLI flag, or `~/.config/copt/config.toml`
+- Drop 3 heavy AWS SDK crates → faster compile times, smaller binary
+- Fall back to existing SigV4 credential chain when no API key is present (backward compatible)
+- Update config file, Raycast script, README, error messages
+
 ## Code Efficiency & Robustness
 
 ### 1. Duplicated `build_editor_command` function — ✅ DONE (v0.3.0)

--- a/scripts/raycast/README.md
+++ b/scripts/raycast/README.md
@@ -17,7 +17,19 @@ Both the original and optimized prompts are auto-saved to `~/.copt/prompts/YYYY-
 
 - [Raycast](https://raycast.com) installed
 - `copt` binary in your PATH (verify with `copt --version`)
-- AWS credentials configured for Bedrock access
+- Bedrock API key (recommended) or AWS credentials configured
+
+### Authentication
+
+The simplest setup is a Bedrock API key:
+
+1. Go to the [Bedrock console](https://console.aws.amazon.com/bedrock) → API keys → Generate long-term key (up to 1 year)
+2. Add to your shell profile (`~/.zshrc`):
+   ```bash
+   export AWS_BEARER_TOKEN_BEDROCK="your-key-here"
+   ```
+
+Alternatively, use standard AWS credentials (`AWS_PROFILE`, `aws configure`, etc.) — copt falls back to the AWS SDK credential chain automatically.
 
 ### Install the Script Command
 

--- a/scripts/raycast/optimize-prompt.sh
+++ b/scripts/raycast/optimize-prompt.sh
@@ -13,7 +13,8 @@
 # @raycast.authorURL https://github.com/praveenc
 
 # --- Configuration ---
-# Raycast runs in a minimal shell — source your profile for PATH and AWS env vars
+# Raycast runs in a minimal shell — source your profile for PATH
+# If using Bedrock API keys, set AWS_BEARER_TOKEN_BEDROCK in your shell profile
 if [ -f "$HOME/.zshrc" ]; then
   source "$HOME/.zshrc" 2>/dev/null
 elif [ -f "$HOME/.zprofile" ]; then
@@ -25,9 +26,8 @@ export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:/opt/homebrew/bin:
 COPT_BIN="${COPT_BIN:-copt}"
 
 # Ensure AWS credentials are available
-# Set these if your .zshrc doesn't export them, or override via Raycast env vars
-# AWS_PROFILE="${AWS_PROFILE:-default}"
-# AWS_REGION="${AWS_REGION:-us-west-2}"
+# Preferred: set AWS_BEARER_TOKEN_BEDROCK in your shell profile (simplest)
+# Alternative: AWS_PROFILE + AWS_REGION for SigV4 credential chain
 
 # --- Preflight ---
 if ! command -v "$COPT_BIN" &>/dev/null; then

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -71,8 +71,12 @@ impl Default for AnthropicConfig {
 pub struct BedrockConfig {
     /// AWS region
     pub region: String,
-    /// AWS profile name
+    /// AWS profile name (for SigV4 fallback)
     pub profile: Option<String>,
+    /// Bedrock API key (Bearer token) — preferred auth method
+    pub api_key: Option<String>,
+    /// Environment variable name for API key
+    pub api_key_env: String,
     /// Maximum tokens for requests
     pub max_tokens: u32,
 }
@@ -82,6 +86,8 @@ impl Default for BedrockConfig {
         Self {
             region: "us-west-2".to_string(),
             profile: None,
+            api_key: None,
+            api_key_env: "AWS_BEARER_TOKEN_BEDROCK".to_string(),
             max_tokens: 4096,
         }
     }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -75,8 +75,6 @@ pub struct BedrockConfig {
     pub profile: Option<String>,
     /// Bedrock API key (Bearer token) — preferred auth method
     pub api_key: Option<String>,
-    /// Environment variable name for API key
-    pub api_key_env: String,
     /// Maximum tokens for requests
     pub max_tokens: u32,
 }
@@ -87,7 +85,6 @@ impl Default for BedrockConfig {
             region: "us-west-2".to_string(),
             profile: None,
             api_key: None,
-            api_key_env: "AWS_BEARER_TOKEN_BEDROCK".to_string(),
             max_tokens: 4096,
         }
     }
@@ -206,7 +203,7 @@ fn dirs_home() -> Option<PathBuf> {
         .or_else(|| std::env::var("USERPROFILE").ok().map(PathBuf::from))
 }
 
-/// Create a default configuration file
+/// Create a default configuration file with commented guidance
 pub fn create_default_config() -> Result<PathBuf> {
     let config_path = get_config_path();
 
@@ -215,9 +212,37 @@ pub fn create_default_config() -> Result<PathBuf> {
             .with_context(|| format!("Failed to create config directory: {}", parent.display()))?;
     }
 
-    let default_config = Config::default();
-    let content =
-        toml::to_string_pretty(&default_config).context("Failed to serialize default config")?;
+    let content = r#"# copt configuration
+# CLI arguments always take precedence over these values.
+
+[default]
+provider = "bedrock"       # "bedrock" or "anthropic"
+model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+# Aliases: "sonnet", "opus", "haiku", "sonnet-4.5", "opus-4.5", "haiku-4.5"
+
+[anthropic]
+# api_key_env = "ANTHROPIC_API_KEY"   # env var name (default)
+max_tokens = 4096
+
+[bedrock]
+region = "us-west-2"
+# api_key = ""             # Bedrock API key (Bearer token) — preferred auth
+                           # Or set AWS_BEARER_TOKEN_BEDROCK env var
+                           # Falls back to AWS credential chain (SigV4) if not set
+max_tokens = 4096
+
+[output]
+color = true
+format = "pretty"          # "pretty", "json", or "quiet"
+show_diff = false
+
+[rules]
+enabled_categories = ["all"]
+disabled = []
+disabled_categories = []
+
+[rules.severity_overrides]
+"#;
 
     std::fs::write(&config_path, content)
         .with_context(|| format!("Failed to write config file: {}", config_path.display()))?;

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -1,6 +1,8 @@
-//! AWS Bedrock client implementation
+//! AWS Bedrock client implementations
 //!
-//! Provides access to Claude models via AWS Bedrock using inference profile IDs.
+//! Provides access to Claude models via AWS Bedrock using:
+//! - Bearer token auth (API keys) via the Converse API — preferred
+//! - SigV4 auth (AWS SDK credential chain) via InvokeModel — fallback
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -163,37 +165,7 @@ impl BedrockClient {
 
     /// Convert Anthropic model ID to Bedrock inference profile model ID
     fn get_bedrock_model_id(model: &str) -> String {
-        match model {
-            // Direct inference profile IDs - pass through
-            m if m.starts_with("us.anthropic.") || m.starts_with("global.anthropic.") => {
-                m.to_string()
-            }
-
-            // Map short names to inference profile IDs
-            "claude-sonnet-4-5-20250929" | "claude-sonnet-4.5" | "sonnet-4.5" | "sonnet" => {
-                "us.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string()
-            }
-            "claude-haiku-4-5-20251001" | "claude-haiku-4.5" | "haiku-4.5" | "haiku" => {
-                "us.anthropic.claude-haiku-4-5-20251001-v1:0".to_string()
-            }
-            "claude-opus-4-5-20251101" | "claude-opus-4.5" | "opus-4.5" | "opus" => {
-                "global.anthropic.claude-opus-4-5-20251101-v1:0".to_string()
-            }
-
-            // Legacy model ID format - convert to inference profile
-            "anthropic.claude-sonnet-4-5-20250929-v1:0" => {
-                "us.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string()
-            }
-            "anthropic.claude-haiku-4-5-20251001-v1:0" => {
-                "us.anthropic.claude-haiku-4-5-20251001-v1:0".to_string()
-            }
-            "anthropic.claude-opus-4-5-20251101-v1:0" => {
-                "global.anthropic.claude-opus-4-5-20251101-v1:0".to_string()
-            }
-
-            // Default: assume it's already a valid model ID
-            other => other.to_string(),
-        }
+        get_bedrock_model_id(model)
     }
 }
 
@@ -261,7 +233,295 @@ impl LlmClient for BedrockClient {
     }
 }
 
-/// Request body for Bedrock (Anthropic Claude format)
+/// Convert Anthropic model ID to Bedrock inference profile model ID
+///
+/// Shared between BedrockClient (SigV4) and BedrockApiKeyClient (Bearer token).
+fn get_bedrock_model_id(model: &str) -> String {
+    match model {
+        // Direct inference profile IDs - pass through
+        m if m.starts_with("us.anthropic.") || m.starts_with("global.anthropic.") => m.to_string(),
+
+        // Map short names to inference profile IDs
+        "claude-sonnet-4-5-20250929" | "claude-sonnet-4.5" | "sonnet-4.5" | "sonnet" => {
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string()
+        }
+        "claude-haiku-4-5-20251001" | "claude-haiku-4.5" | "haiku-4.5" | "haiku" => {
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0".to_string()
+        }
+        "claude-opus-4-5-20251101" | "claude-opus-4.5" | "opus-4.5" | "opus" => {
+            "global.anthropic.claude-opus-4-5-20251101-v1:0".to_string()
+        }
+
+        // Legacy model ID format - convert to inference profile
+        "anthropic.claude-sonnet-4-5-20250929-v1:0" => {
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string()
+        }
+        "anthropic.claude-haiku-4-5-20251001-v1:0" => {
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0".to_string()
+        }
+        "anthropic.claude-opus-4-5-20251101-v1:0" => {
+            "global.anthropic.claude-opus-4-5-20251101-v1:0".to_string()
+        }
+
+        // Default: assume it's already a valid model ID
+        other => other.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BedrockApiKeyClient — Bearer token auth via Converse API
+// ---------------------------------------------------------------------------
+
+/// AWS Bedrock client using API key (Bearer token) authentication.
+///
+/// Uses the Converse API endpoint with a simple `Authorization: Bearer <key>` header.
+/// No AWS SDK required — just reqwest HTTP calls.
+pub struct BedrockApiKeyClient {
+    client: reqwest::Client,
+    api_key: String,
+    region: String,
+}
+
+impl BedrockApiKeyClient {
+    /// Create a new Bedrock API key client
+    pub fn new(api_key: String, region: &str) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .build()
+            .context("Failed to create HTTP client")?;
+
+        Ok(Self {
+            client,
+            api_key,
+            region: region.to_string(),
+        })
+    }
+
+    /// Check connectivity using a minimal Converse API call
+    pub async fn check_connectivity(&self, model_id: &str) -> Result<()> {
+        let model_id = get_bedrock_model_id(model_id);
+        let url = format!(
+            "https://bedrock-runtime.{}.amazonaws.com/model/{}/converse",
+            self.region, model_id
+        );
+
+        let request = ConverseRequest {
+            system: None,
+            messages: vec![ConverseMessage {
+                role: "user".to_string(),
+                content: vec![ConverseContentBlock {
+                    text: "hi".to_string(),
+                }],
+            }],
+            inference_config: Some(ConverseInferenceConfig {
+                max_tokens: 1,
+                temperature: None,
+            }),
+        };
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to connect to Bedrock")?;
+
+        let status = response.status();
+        if status.is_success() || status.as_u16() == 429 {
+            // 429 = throttled, but means auth worked
+            Ok(())
+        } else {
+            let error_text = response.text().await.unwrap_or_default();
+            match status.as_u16() {
+                401 => anyhow::bail!(
+                    "Bedrock API key is invalid or malformed.\n\n\
+                    Ensure AWS_BEARER_TOKEN_BEDROCK is set correctly.\n\
+                    Region: {}\n\
+                    Error: {}",
+                    self.region,
+                    error_text
+                ),
+                403 => anyhow::bail!(
+                    "Bedrock API key is expired or lacks permissions.\n\n\
+                    Generate a new key in the Bedrock console → API keys.\n\
+                    Keys are region-scoped — ensure the key was created in '{}'.\n\
+                    Error: {}",
+                    self.region,
+                    error_text
+                ),
+                404 => anyhow::bail!(
+                    "Model not available.\n\n\
+                    Ensure you have enabled the model in the Bedrock console\n\
+                    and the model is available in the '{}' region.\n\
+                    Model: {}\n\
+                    Error: {}",
+                    self.region,
+                    model_id,
+                    error_text
+                ),
+                _ => anyhow::bail!(
+                    "Bedrock API request failed (HTTP {}).\n\n\
+                    Region: {}\n\
+                    Model: {}\n\
+                    Error: {}",
+                    status,
+                    self.region,
+                    model_id,
+                    error_text
+                ),
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl LlmClient for BedrockApiKeyClient {
+    async fn complete(
+        &self,
+        system: &str,
+        user_message: &str,
+        model: &str,
+        max_tokens: u32,
+    ) -> Result<String> {
+        let model_id = get_bedrock_model_id(model);
+        let url = format!(
+            "https://bedrock-runtime.{}.amazonaws.com/model/{}/converse",
+            self.region, model_id
+        );
+
+        let request = ConverseRequest {
+            system: Some(vec![ConverseContentBlock {
+                text: system.to_string(),
+            }]),
+            messages: vec![ConverseMessage {
+                role: "user".to_string(),
+                content: vec![ConverseContentBlock {
+                    text: user_message.to_string(),
+                }],
+            }],
+            inference_config: Some(ConverseInferenceConfig {
+                max_tokens,
+                temperature: Some(0.3),
+            }),
+        };
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to send request to Bedrock")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Bedrock API request failed (HTTP {}): {}",
+                status,
+                error_text
+            );
+        }
+
+        let api_response: ConverseResponse = response
+            .json()
+            .await
+            .context("Failed to parse Bedrock Converse response")?;
+
+        let text = api_response
+            .output
+            .message
+            .content
+            .into_iter()
+            .map(|block| block.text)
+            .collect::<Vec<_>>()
+            .join("");
+
+        Ok(text)
+    }
+
+    fn provider_name(&self) -> &str {
+        "bedrock"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Converse API request/response types (for BedrockApiKeyClient)
+// ---------------------------------------------------------------------------
+
+/// Request body for Bedrock Converse API
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConverseRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<Vec<ConverseContentBlock>>,
+    messages: Vec<ConverseMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inference_config: Option<ConverseInferenceConfig>,
+}
+
+/// A message in the Converse API format
+#[derive(Debug, Serialize)]
+struct ConverseMessage {
+    role: String,
+    content: Vec<ConverseContentBlock>,
+}
+
+/// A content block (used in both request and response)
+#[derive(Debug, Serialize, Deserialize)]
+struct ConverseContentBlock {
+    text: String,
+}
+
+/// Inference configuration for Converse API
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConverseInferenceConfig {
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+}
+
+/// Response from Bedrock Converse API
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConverseResponse {
+    output: ConverseOutput,
+    #[allow(dead_code)]
+    stop_reason: Option<String>,
+    #[allow(dead_code)]
+    usage: Option<ConverseUsage>,
+}
+
+/// Output wrapper in Converse response
+#[derive(Debug, Deserialize)]
+struct ConverseOutput {
+    message: ConverseOutputMessage,
+}
+
+/// Message in Converse response
+#[derive(Debug, Deserialize)]
+struct ConverseOutputMessage {
+    #[allow(dead_code)]
+    role: String,
+    content: Vec<ConverseContentBlock>,
+}
+
+/// Usage statistics from Converse API
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct ConverseUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+}
+
+/// Request body for Bedrock (Anthropic Claude format) — used by SigV4 client
 #[derive(Debug, Serialize)]
 struct BedrockRequest {
     anthropic_version: String,
@@ -315,11 +575,11 @@ mod tests {
     fn test_model_id_conversion_inference_profiles() {
         // Direct inference profile IDs should pass through
         assert_eq!(
-            BedrockClient::get_bedrock_model_id("us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
+            get_bedrock_model_id("us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
             "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         );
         assert_eq!(
-            BedrockClient::get_bedrock_model_id("global.anthropic.claude-opus-4-5-20251101-v1:0"),
+            get_bedrock_model_id("global.anthropic.claude-opus-4-5-20251101-v1:0"),
             "global.anthropic.claude-opus-4-5-20251101-v1:0"
         );
     }
@@ -327,23 +587,23 @@ mod tests {
     #[test]
     fn test_model_id_conversion_short_names() {
         assert_eq!(
-            BedrockClient::get_bedrock_model_id("claude-sonnet-4-5-20250929"),
+            get_bedrock_model_id("claude-sonnet-4-5-20250929"),
             "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         );
         assert_eq!(
-            BedrockClient::get_bedrock_model_id("sonnet-4.5"),
+            get_bedrock_model_id("sonnet-4.5"),
             "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         );
         assert_eq!(
-            BedrockClient::get_bedrock_model_id("sonnet"),
+            get_bedrock_model_id("sonnet"),
             "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         );
         assert_eq!(
-            BedrockClient::get_bedrock_model_id("opus-4.5"),
+            get_bedrock_model_id("opus-4.5"),
             "global.anthropic.claude-opus-4-5-20251101-v1:0"
         );
         assert_eq!(
-            BedrockClient::get_bedrock_model_id("haiku-4.5"),
+            get_bedrock_model_id("haiku-4.5"),
             "us.anthropic.claude-haiku-4-5-20251001-v1:0"
         );
     }
@@ -351,8 +611,66 @@ mod tests {
     #[test]
     fn test_model_id_conversion_legacy() {
         assert_eq!(
-            BedrockClient::get_bedrock_model_id("anthropic.claude-sonnet-4-5-20250929-v1:0"),
+            get_bedrock_model_id("anthropic.claude-sonnet-4-5-20250929-v1:0"),
             "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         );
+    }
+
+    #[test]
+    fn test_api_key_client_creation() {
+        let client = BedrockApiKeyClient::new("test-key".to_string(), "us-west-2");
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    fn test_api_key_client_provider_name() {
+        let client = BedrockApiKeyClient::new("test-key".to_string(), "us-west-2").unwrap();
+        assert_eq!(client.provider_name(), "bedrock");
+    }
+
+    #[test]
+    fn test_converse_request_serialization() {
+        let request = ConverseRequest {
+            system: Some(vec![ConverseContentBlock {
+                text: "You are helpful.".to_string(),
+            }]),
+            messages: vec![ConverseMessage {
+                role: "user".to_string(),
+                content: vec![ConverseContentBlock {
+                    text: "Hello".to_string(),
+                }],
+            }],
+            inference_config: Some(ConverseInferenceConfig {
+                max_tokens: 4096,
+                temperature: Some(0.3),
+            }),
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["messages"][0]["role"], "user");
+        assert_eq!(json["messages"][0]["content"][0]["text"], "Hello");
+        assert_eq!(json["system"][0]["text"], "You are helpful.");
+        assert_eq!(json["inferenceConfig"]["maxTokens"], 4096);
+        // f32 precision: 0.3 serializes to ~0.30000001
+        let temp = json["inferenceConfig"]["temperature"].as_f64().unwrap();
+        assert!((temp - 0.3).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_converse_response_deserialization() {
+        let json = r#"{
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [{"text": "Hello there!"}]
+                }
+            },
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 5}
+        }"#;
+
+        let response: ConverseResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.output.message.content[0].text, "Hello there!");
+        assert_eq!(response.stop_reason, Some("end_turn".to_string()));
     }
 }

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -84,8 +84,11 @@ impl BedrockClient {
                 {
                     anyhow::bail!(
                         "AWS credentials not found or invalid.\n\n\
-                        Please ensure you have valid AWS credentials configured:\n\
-                        • Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables, or\n\
+                        Simplest fix: use a Bedrock API key instead:\n\
+                        export AWS_BEARER_TOKEN_BEDROCK=\"your-key-here\"\n\
+                        (Generate at: Bedrock console → API keys)\n\n\
+                        Or configure AWS credentials:\n\
+                        • Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or\n\
                         • Configure credentials in ~/.aws/credentials, or\n\
                         • Use AWS SSO: run 'aws sso login'\n\n\
                         Region: {}\n\

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -8,6 +8,7 @@ mod anthropic;
 mod bedrock;
 
 pub use anthropic::AnthropicClient;
+pub use bedrock::BedrockApiKeyClient;
 pub use bedrock::BedrockClient;
 
 use anyhow::Result;

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,18 +294,9 @@ fn apply_config_defaults(cli: &mut Cli, matches: &clap::ArgMatches) {
 
     // Apply Bedrock API key from config if not set via CLI or env var
     if cli.bedrock_api_key.is_none() {
-        // Try the env var name from config (in case user customized it)
-        if let Ok(key) = std::env::var(&config.bedrock.api_key_env) {
+        if let Some(ref key) = config.bedrock.api_key {
             if !key.is_empty() {
-                cli.bedrock_api_key = Some(key);
-            }
-        }
-        // Fall back to direct config value
-        if cli.bedrock_api_key.is_none() {
-            if let Some(ref key) = config.bedrock.api_key {
-                if !key.is_empty() {
-                    cli.bedrock_api_key = Some(key.clone());
-                }
+                cli.bedrock_api_key = Some(key.clone());
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,14 @@ struct Cli {
     #[arg(long, default_value = "us-west-2", hide_default_value = true)]
     region: String,
 
+    /// Bedrock API key (Bearer token). Overrides AWS credential chain.
+    #[arg(
+        long = "bedrock-api-key",
+        env = "AWS_BEARER_TOKEN_BEDROCK",
+        hide = true
+    )]
+    bedrock_api_key: Option<String>,
+
     /// Output format: pretty, json, quiet
     #[arg(long, value_enum, default_value = "pretty", hide_default_value = true)]
     format: OutputFormat,
@@ -284,6 +292,24 @@ fn apply_config_defaults(cli: &mut Cli, matches: &clap::ArgMatches) {
         cli.diff = true;
     }
 
+    // Apply Bedrock API key from config if not set via CLI or env var
+    if cli.bedrock_api_key.is_none() {
+        // Try the env var name from config (in case user customized it)
+        if let Ok(key) = std::env::var(&config.bedrock.api_key_env) {
+            if !key.is_empty() {
+                cli.bedrock_api_key = Some(key);
+            }
+        }
+        // Fall back to direct config value
+        if cli.bedrock_api_key.is_none() {
+            if let Some(ref key) = config.bedrock.api_key {
+                if !key.is_empty() {
+                    cli.bedrock_api_key = Some(key.clone());
+                }
+            }
+        }
+    }
+
     if cli.verbose {
         let config_path = cli::config::get_config_path();
         if config_path.exists() {
@@ -323,20 +349,32 @@ async fn check_provider_connectivity(cli: &Cli) -> Result<()> {
 
     match cli.provider {
         Provider::Bedrock => {
+            let auth_method = if cli.bedrock_api_key.is_some() {
+                "API key"
+            } else {
+                "AWS credentials"
+            };
             if !cli.quiet && cli.format != OutputFormat::Quiet {
                 print!(
-                    "{} Checking AWS Bedrock connectivity ({})... ",
+                    "{} Checking Bedrock connectivity ({}, {})... ",
                     "⚡".cyan(),
-                    cli.region.bright_black()
+                    cli.region.bright_black(),
+                    auth_method.bright_black()
                 );
                 // Flush to show the message immediately
                 use std::io::Write;
                 let _ = std::io::stdout().flush();
             }
 
-            let client = llm::BedrockClient::new(&cli.region).await?;
+            let connectivity_result = if let Some(ref api_key) = cli.bedrock_api_key {
+                let client = llm::BedrockApiKeyClient::new(api_key.clone(), &cli.region)?;
+                client.check_connectivity(&cli.model).await
+            } else {
+                let client = llm::BedrockClient::new(&cli.region).await?;
+                client.check_connectivity(&cli.model).await
+            };
 
-            match client.check_connectivity(&cli.model).await {
+            match connectivity_result {
                 Ok(()) => {
                     if !cli.quiet && cli.format != OutputFormat::Quiet {
                         println!("{}", "✓ Connected".green());
@@ -629,7 +667,13 @@ async fn run_optimization(cli: &Cli, prompt: &str) -> Result<OptimizationResult>
                 std::env::var("ANTHROPIC_API_KEY")
                     .context("ANTHROPIC_API_KEY environment variable not set")?,
             )?),
-            Provider::Bedrock => Box::new(llm::BedrockClient::new(&cli.region).await?),
+            Provider::Bedrock => {
+                if let Some(ref api_key) = cli.bedrock_api_key {
+                    Box::new(llm::BedrockApiKeyClient::new(api_key.clone(), &cli.region)?)
+                } else {
+                    Box::new(llm::BedrockClient::new(&cli.region).await?)
+                }
+            }
         };
 
         let result =
@@ -855,7 +899,13 @@ async fn run_interactive_mode(cli: &Cli, prompt: &str) -> Result<()> {
                 std::env::var("ANTHROPIC_API_KEY")
                     .context("ANTHROPIC_API_KEY environment variable not set")?,
             )?),
-            Provider::Bedrock => Box::new(llm::BedrockClient::new(&cli.region).await?),
+            Provider::Bedrock => {
+                if let Some(ref api_key) = cli.bedrock_api_key {
+                    Box::new(llm::BedrockApiKeyClient::new(api_key.clone(), &cli.region)?)
+                } else {
+                    Box::new(llm::BedrockClient::new(&cli.region).await?)
+                }
+            }
         };
 
         let prompt_type = analyzer::classify_prompt(prompt);

--- a/src/tui/snapshots/copt__tui__snapshot_tests__diff_view.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__diff_view.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.1                                               
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.2                                               
                                                                                 
 ────────────────────────────────────────────────────────────────────────────────
 ┌ ✨  Changes ──────────────────────────────────────────────────────────────────┐

--- a/src/tui/snapshots/copt__tui__snapshot_tests__help_view.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__help_view.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.1                                               
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.2                                               
                                                                                 
 ────────────────────────────────────────────────────────────────────────────────
 ┌ Keyboard Shortcuts ──────────────────────────────────────────────────────────┐

--- a/src/tui/snapshots/copt__tui__snapshot_tests__main_view_analysis_done.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__main_view_analysis_done.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.1                                               
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.2                                               
 Optimize prompts for Claude 4.5                                                 
 📥  Input: test_prompt.txt (53 chars, 12 tokens)                                 
 ────────────────────────────────────────────────────────────────────────────────

--- a/src/tui/snapshots/copt__tui__snapshot_tests__main_view_done.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__main_view_done.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.1                                               
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.2                                               
 Optimize prompts for Claude 4.5                                                 
 📥  Input: test_prompt.txt (53 chars, 12 tokens)                                 
 ────────────────────────────────────────────────────────────────────────────────

--- a/src/tui/snapshots/copt__tui__snapshot_tests__no_issues.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__no_issues.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.1                                               
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.2                                               
 Optimize prompts for Claude 4.5                                                 
 📥  Input: stdin (30 chars, 5 tokens)                                            
 ────────────────────────────────────────────────────────────────────────────────

--- a/src/tui/snapshots/copt__tui__snapshot_tests__offline_mode.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__offline_mode.snap
@@ -2,7 +2,7 @@
 source: src/tui/snapshot_tests.rs
 expression: output
 ---
-⚡  CLAUDE PROMPT OPTIMIZER v0.3.1 [OFFLINE MODE]                                
+⚡  CLAUDE PROMPT OPTIMIZER v0.3.2 [OFFLINE MODE]                                
 Static analysis only (no LLM calls)                                             
 📥  Input: test_prompt.txt (53 chars, 12 tokens)                                 
 ────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# feat: Bedrock API Key authentication with SigV4 fallback

## Summary

Adds Bearer token authentication for Amazon Bedrock via the new [API Keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) feature, replacing the complex AWS credential chain as the default auth path. Keys support up to 1-year expiry — effectively "set and forget" for a developer CLI tool.

The existing SigV4 (AWS SDK) auth is preserved as an automatic fallback when no API key is configured.

## Motivation

The #1 friction point for new users was Bedrock authentication. The SigV4 credential chain requires:
- AWS CLI installed and configured
- IAM user/role with correct Bedrock permissions
- `aws configure` or `AWS_PROFILE` + `AWS_REGION` environment variables
- Understanding of AWS credential resolution order

Bedrock API Keys reduce this to a single string — copy from the Bedrock console, paste into config or env var, done.

## Changes

### Core: `BedrockApiKeyClient` (`src/llm/bedrock.rs`)

- New `BedrockApiKeyClient` struct using `reqwest` + Bedrock Converse API
- `Authorization: Bearer <key>` header on all requests
- Converse API types: `ConverseRequest`, `ConverseResponse`, `ConverseMessage`, `ConverseContentBlock`, `ConverseInferenceConfig`, `ConverseOutput`, `ConverseOutputMessage`, `ConverseUsage`
- `check_connectivity()` with descriptive error messages for 401 (invalid key), 403 (expired/no permissions), 404 (model not available)
- Extracted `get_bedrock_model_id()` to module-level shared function (was a `BedrockClient` method)
- Implements `LlmClient` trait — drop-in replacement for `BedrockClient`

### CLI & Config

- `--bedrock-api-key` CLI flag (hidden, reads `AWS_BEARER_TOKEN_BEDROCK` env via clap)
- `api_key` field added to `BedrockConfig` in `src/cli/config.rs`
- Key resolution order: CLI flag → env var → config.toml → SigV4 fallback
- `create_default_config()` rewritten to emit a hand-crafted commented template with API key guidance (was serialized defaults)
- Removed `api_key_env` indirection (users put actual keys in it instead of env var names — footgun)

### Wiring (`src/main.rs`)

- `apply_config_defaults()` loads API key from config.toml when not set via CLI/env
- `check_provider_connectivity()` uses API key client when key present, SigV4 otherwise
- `run_optimization()` and `run_interactive_mode()` — same dual-path client selection
- Connectivity status shows auth method: `"Checking Bedrock connectivity (us-west-2, API key)..."`

### Docs & UX

- README Quick Start rewritten for API key-first flow
- Raycast script and README updated with API key auth info
- SigV4 error messages now suggest API keys as the simplest fix
- CHANGELOG v0.3.2 entry
- IMPROVEMENTS.md item #10 marked done
- HANDOFF_PROMPT.md updated for v0.3.2

### Tests

- 4 new tests: `test_api_key_client_creation`, `test_api_key_client_provider_name`, `test_converse_request_serialization`, `test_converse_response_deserialization`
- Test suite: 97 → 101 (all passing)
- Snapshot files updated for version bump

## Key resolution order

```
--bedrock-api-key flag
        ↓ (not set)
AWS_BEARER_TOKEN_BEDROCK env var
        ↓ (not set)
api_key in ~/.config/copt/config.toml [bedrock] section
        ↓ (not set)
SigV4 fallback (AWS SDK credential chain)
```

## Config example

```toml
[bedrock]
region = "us-west-2"
api_key = "br-..."   # from Bedrock console → API keys
```

## Diff stats

```
18 files changed, 559 insertions(+), 101 deletions(-)
```

## Commits

| Hash | Message |
|------|---------|
| `e6ec5c1` | docs: add bedrock api key auth to improvements and handoff |
| `a8d4b7e` | feat: add bedrock api key bearer token auth with sigv4 fallback |
| `e892f00` | docs: update readme, raycast script, and error messages for api key auth |
| `a78870a` | fix: simplify bedrock config, drop api_key_env footgun, improve config template |
| `facd7e2` | docs: mark bedrock api key auth as done in improvements |
| `181f1aa` | chore: bump v0.3.2 with changelog, snapshots, and handoff |

## Testing

- [x] `make ci-quiet` — fmt, clippy, build, 101 tests passing
- [x] Manual test with real Bedrock API key (Bearer token auth, Converse API)
- [x] SigV4 fallback path unchanged (no API key configured → existing behavior)
- [x] `--config-init` generates correct commented template
- [x] Key loaded from config.toml when env var not set
