### PR TITLE
feat: Claude 4.7 family support (Opus 4.7 GA + reserved Sonnet/Haiku 4.7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ images/tmp/
 # Test prompt files (if any)
 test_prompt.txt
 
+# Local seed prompts used during feature work (kept untracked)
+docs/SEED_PROMPT.txt
+docs/SEED_PROMPT-*.txt
+
 # bv (beads viewer) local config and caches
 .bv/
 .claude/*.local.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to `copt` (Claude Prompt Optimizer) will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Claude 4.7 family support**: New `opus-4.7` model alias resolves to `global.anthropic.claude-opus-4-7-v1:0` (released 2026-04-16). Selecting this model routes optimization through a Claude 4.7-specific meta-prompt.
+- **4.7-specific optimizer rules**: Literal instruction following, adaptive thinking guidance, effort-level awareness (xhigh/high/medium/low/max), scratchpad/memory directives, condensed context (drops 4.5/4.6 scaffolding), tone specification, response-length calibration, and vision-aware instructions (high-res images, 1:1 pixel coordinates).
+- **Model family classifier**: New `llm::ModelFamily` enum (`Claude45`, `Claude46`, `Claude47`) drives meta-prompt selection from the model ID.
+- **Reserved aliases**: `sonnet-4.7` and `haiku-4.7` are registered; selecting them produces a clear "not yet released" error (only Opus 4.7 is GA as of 2026-04-16). `--offline` bypasses the guard so analysis still works.
+- **4.7-specific enhancement hints**: New `optimizer::get_family_enhancements()` appends 4.7 guidance (scope explicitness, scratchpad directives, tone, length calibration, vision) to the LLM user message when targeting Opus 4.7.
+
+### Changed
+
+- `llm::build_optimization_message` now takes a `ModelFamily` parameter so the user message labels the target model family correctly ("Optimize this prompt for Claude 4.7:" vs 4.5).
+- `optimizer::optimize_with_llm` selects the meta-prompt via `system_prompt_for_family` instead of the hard-coded 4.5 prompt. Unknown model IDs continue to fall back to the 4.5 meta-prompt.
+
+### Technical
+
+- Test suite: 101 → 111 (10 new tests covering family classification, alias resolution, Bedrock ID mapping, system-prompt selection, and the unreleased-model guard).
+- `OPTIMIZER_SYSTEM_PROMPT` is preserved as a back-compat re-export of `OPTIMIZER_SYSTEM_PROMPT_4_5`.
+
 ## [0.3.2] - 2026-02-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Claude 4.7 family support**: New `opus-4.7` model alias resolves to `global.anthropic.claude-opus-4-7-v1:0` (released 2026-04-16). Selecting this model routes optimization through a Claude 4.7-specific meta-prompt.
+- **Claude 4.7 family support**: New `opus-4.7` model alias resolves to the `global.anthropic.claude-opus-4-7` Bedrock inference profile (released 2026-04-16). Selecting this model routes optimization through a Claude 4.7-specific meta-prompt.
 - **4.7-specific optimizer rules**: Literal instruction following, adaptive thinking guidance, effort-level awareness (xhigh/high/medium/low/max), scratchpad/memory directives, condensed context (drops 4.5/4.6 scaffolding), tone specification, response-length calibration, and vision-aware instructions (high-res images, 1:1 pixel coordinates).
 - **Model family classifier**: New `llm::ModelFamily` enum (`Claude45`, `Claude46`, `Claude47`) drives meta-prompt selection from the model ID.
 - **Reserved aliases**: `sonnet-4.7` and `haiku-4.7` are registered; selecting them produces a clear "not yet released" error (only Opus 4.7 is GA as of 2026-04-16). `--offline` bypasses the guard so analysis still works.
 - **4.7-specific enhancement hints**: New `optimizer::get_family_enhancements()` appends 4.7 guidance (scope explicitness, scratchpad directives, tone, length calibration, vision) to the LLM user message when targeting Opus 4.7.
+- **`-t` / `--target` CLI flag**: Decouple the rewriter model (`-m`) from the target family whose best-practices the rewrite applies. Values: `auto` (default; infers from `-m`), `4.5`, `4.6`, `4.7`. Example: `copt -m sonnet -t 4.7` uses Sonnet 4.5 as the rewriter and Opus 4.7 prompting rules as the target.
+- **`sonnet-4.6` alias**: Resolves to the `global.anthropic.claude-sonnet-4-6` Bedrock inference profile. Added alongside the 4.7 work after confirming the profile exists in `us-west-2`.
 
 ### Changed
 
 - `llm::build_optimization_message` now takes a `ModelFamily` parameter so the user message labels the target model family correctly ("Optimize this prompt for Claude 4.7:" vs 4.5).
 - `optimizer::optimize_with_llm` selects the meta-prompt via `system_prompt_for_family` instead of the hard-coded 4.5 prompt. Unknown model IDs continue to fall back to the 4.5 meta-prompt.
+- **Corrected Opus 4.7 inference profile ID**: `opus-4.7` now maps to `global.anthropic.claude-opus-4-7` (was an incorrect guess of `global.anthropic.claude-opus-4-7-v1:0` — returned HTTP 400 from Bedrock).
+- **Corrected Opus 4.6 inference profile ID**: `opus-4.6` now maps to `global.anthropic.claude-opus-4-6-v1` (was `us.anthropic.claude-opus-4-6-v1`; the `global.` profile is the supported one).
+- **`temperature` omitted on Claude 4.7**: Both Bedrock clients (SigV4 and Bearer token) now drop `temperature` from requests when the resolved family is `Claude47`, matching the 4.7 migration guide (non-default sampling parameters return 400).
+- **`optimize_with_llm` signature**: Gained a `target_family: Option<ModelFamily>` parameter. `None` preserves historical behaviour (derive family from model); `Some(family)` overrides.
 
 ### Technical
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Options:
       --no-save                  Disable auto-save
   -p, --provider <PROVIDER>      Provider: anthropic, bedrock
   -m, --model <MODEL>            Model ID or alias
+  -t, --target <FAMILY>          Target Claude family: auto (default), 4.5, 4.6, 4.7
       --region <REGION>          AWS region for Bedrock
       --format <FORMAT>          Output format: pretty, json, quiet
       --diff                     Show before/after diff
@@ -170,8 +171,9 @@ Use short aliases instead of full Bedrock ARNs:
 |-------|-------|
 | `sonnet` / `sonnet-4.5` | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` |
 | `opus` / `opus-4.5` | `us.anthropic.claude-opus-4-5-20251101-v1:0` |
-| `opus-4.6` | `us.anthropic.claude-opus-4-6-v1` |
-| `opus-4.7` | `global.anthropic.claude-opus-4-7-v1:0` |
+| `opus-4.6` | `global.anthropic.claude-opus-4-6-v1` |
+| `sonnet-4.6` | `global.anthropic.claude-sonnet-4-6` |
+| `opus-4.7` | `global.anthropic.claude-opus-4-7` |
 | `haiku` / `haiku-4.5` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` |
 
 ```bash
@@ -192,6 +194,23 @@ Selecting `sonnet-4.7` or `haiku-4.7` produces a clear "not yet released" error 
 ```bash
 copt -f prompt.txt -m opus-4.7
 ```
+
+### Targeting a family explicitly (`-t` / `--target`)
+
+By default `copt` infers the target Claude family from `--model` (`-m`). To decouple the rewriter model from the target family — for example, to use a fast, cheap Sonnet 4.5 to produce a prompt tailored for Opus 4.7 — pass `-t`:
+
+```bash
+# Opus 4.7 rewrites for Opus 4.7 (auto)
+copt -f prompt.txt -m opus-4.7
+
+# Sonnet 4.5 rewrites for Opus 4.7 family best-practices
+copt -f prompt.txt -m sonnet -t 4.7
+
+# Opus 4.7 rewrites a prompt that will run on Sonnet 4.5
+copt -f prompt.txt -m opus-4.7 -t 4.5
+```
+
+Accepted values for `-t`: `auto` (default), `4.5`, `4.6`, `4.7`.
 
 ### Common Examples
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # ⚡ copt — Claude Prompt Optimizer
 
-> Optimize your prompts for Claude 4.5 models
+> Optimize your prompts for Claude 4.x models (4.5, 4.6, and 4.7)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.75%2B-orange.svg)](https://www.rust-lang.org/)
 [![Release](https://img.shields.io/github/v/release/praveenc/copt?include_prereleases)](https://github.com/praveenc/copt/releases)
 [![Build](https://img.shields.io/github/actions/workflow/status/praveenc/copt/ci.yml?branch=main)](https://github.com/praveenc/copt/actions)
 
-**Claude 4.5 models** do exactly what you ask — no more, no less. Prompts that worked with Claude 3.x may need adjustment. **copt** analyzes your prompts for anti-patterns and optimizes them using Claude 4.5 itself.
+**Claude 4.5 models** do exactly what you ask — no more, no less. Prompts that worked with Claude 3.x may need adjustment. **copt** analyzes your prompts for anti-patterns and optimizes them using Claude 4.5 itself. With Claude 4.7, prompts also need to account for literal instruction following, adaptive thinking, and calibrated response length — **copt** handles these automatically when you target an `opus-4.7` model.
 
 ---
 
@@ -171,11 +171,26 @@ Use short aliases instead of full Bedrock ARNs:
 | `sonnet` / `sonnet-4.5` | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` |
 | `opus` / `opus-4.5` | `us.anthropic.claude-opus-4-5-20251101-v1:0` |
 | `opus-4.6` | `us.anthropic.claude-opus-4-6-v1` |
+| `opus-4.7` | `global.anthropic.claude-opus-4-7-v1:0` |
 | `haiku` / `haiku-4.5` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` |
 
 ```bash
 copt -f prompt.txt -m opus            # Use Claude Opus 4.5
 copt -f prompt.txt -m haiku           # Use Claude Haiku 4.5
+```
+
+### Claude 4.7 Support
+
+**Opus 4.7** is generally available as of 2026-04-16. Sonnet 4.7 and Haiku 4.7 are not yet released.
+
+When you target `opus-4.7`, **copt** routes optimization through a Claude 4.7-specific meta-prompt that applies eight 4.7 behaviors: **literal instruction following** (the model does exactly what you say), **adaptive thinking guidance** (explicit reasoning directives), **effort-level awareness** (xhigh/high/medium/low/max markers), **scratchpad and memory directives** (working-memory tags), **condensed context** (drops 4.5/4.6 scaffolding that 4.7 doesn't need), **tone specification** (explicit tone markers), **response-length calibration** (explicit length bounds), and **vision-aware instructions** (high-resolution image handling up to 2576px/3.75MP with 1:1 pixel coordinates).
+
+Selecting `sonnet-4.7` or `haiku-4.7` produces a clear "not yet released" error unless you run in `--offline` mode (offline mode still works for analysis).
+
+**Usage:**
+
+```bash
+copt -f prompt.txt -m opus-4.7
 ```
 
 ### Common Examples

--- a/docs/RUST_LEARNINGS.md
+++ b/docs/RUST_LEARNINGS.md
@@ -240,4 +240,147 @@ pub const OPTIMIZER_SYSTEM_PROMPT: &str = OPTIMIZER_SYSTEM_PROMPT_4_5;
 
 ---
 
+### 10. Use project `make` targets, not raw `cargo` commands
+
+**Problem:** The project has a `Makefile` with curated build/test/lint targets (`make ci`, `make ci-quiet`, `make ci-release`, `make release`, `make check`). Bypassing them with raw `cargo build --release` or `cargo test` skips project conventions (e.g., the `-D warnings` clippy flag, the coordinated fmt→lint→build→test order) and produces inconsistent CI/local behaviour.
+
+```bash
+# ❌ WRONG - bypasses project conventions, may pass locally and fail CI
+cargo build --release
+cargo test
+```
+
+```bash
+# ✅ CORRECT - use project targets
+make release        # release build
+make ci-quiet       # concise CI gate (agent-friendly)
+make ci             # full debug CI gate
+make ci-release     # full release CI gate
+make check          # auto-fix formatting, then lint and test
+```
+
+**Rule:** Before running ANY `cargo` command, check `Makefile` for a target that covers the same intent. Raw `cargo` is only appropriate for one-off things the Makefile doesn't cover (e.g., `cargo run -- <specific args>` during live testing, or `cargo insta test --accept` for snapshot updates).
+
+---
+
+### 11. `String::replace` silently no-ops when the needle is absent
+
+**Problem:** Deriving a sibling filename from a "primary" path with `replace` is only safe if the sentinel substring is guaranteed to be present. When it's absent, `replace` returns the input unchanged — which can produce a silent filename collision that then gets overwritten by a later write.
+
+This was the root cause of a `-o <path>` bug in `src/main.rs` where explicit user-supplied paths (e.g. `-o /tmp/foo.txt`) clobbered the optimized output with the original prompt:
+
+```rust
+// ❌ WRONG - returns the same path unchanged when the sentinel isn't there
+let original_path = {
+    let filename = path.file_name().unwrap().to_string_lossy();
+    // When `filename` is "foo.txt" (no "_optimized.txt" suffix),
+    // `original_filename` is STILL "foo.txt" — same path as `path`.
+    let original_filename = filename.replace("_optimized.txt", "_original.txt");
+    path.with_file_name(original_filename)
+};
+
+// Then:
+tokio::fs::write(path, &result.optimized).await?;        // writes optimized
+tokio::fs::write(&original_path, &result.original).await?; // OVERWRITES same file with original
+```
+
+```rust
+// ✅ CORRECT - check the sentinel is actually there, otherwise derive a
+// different sibling name
+let original_path = {
+    let filename = path.file_name().unwrap().to_string_lossy();
+    if filename.contains("_optimized.txt") {
+        let original_filename = filename.replace("_optimized.txt", "_original.txt");
+        path.with_file_name(original_filename)
+    } else {
+        // Fallback: `<stem>.original.<ext>` so we never collide with `path`.
+        let stem = path.file_stem().map(|s| s.to_string_lossy().to_string()).unwrap_or_default();
+        let ext  = path.extension().map(|e| e.to_string_lossy().to_string()).unwrap_or_default();
+        let fallback = if ext.is_empty() {
+            format!("{stem}.original")
+        } else {
+            format!("{stem}.original.{ext}")
+        };
+        path.with_file_name(fallback)
+    }
+};
+```
+
+**Rule:** When deriving a sibling filename via `replace`, either (a) assert the needle is present first, or (b) use an explicit conditional with a fallback that is provably different from the input. Any two consecutive writes in a pipeline must target demonstrably different paths.
+
+---
+
+### 12. Don't guess Bedrock inference profile IDs; list them
+
+**Problem:** Bedrock inference profile IDs don't follow a single naming convention. Some end in `-v1:0`, some in `-v1`, some have no version suffix at all:
+
+| Model | Actual profile ID |
+|-------|-------------------|
+| Opus 4.5 | `global.anthropic.claude-opus-4-5-20251101-v1:0` |
+| Opus 4.6 | `global.anthropic.claude-opus-4-6-v1` |
+| Sonnet 4.6 | `global.anthropic.claude-sonnet-4-6` |
+| Opus 4.7 | `global.anthropic.claude-opus-4-7` |
+
+Guessing `global.anthropic.claude-opus-4-7-v1:0` produces a convincing-looking but wrong string that returns `HTTP 400 {"message":"The provided model identifier is invalid."}` at runtime — not caught by tests, only by a live call.
+
+```rust
+// ❌ WRONG - plausible-looking extrapolation
+"opus-4.7" => "global.anthropic.claude-opus-4-7-v1:0".to_string(),
+```
+
+```rust
+// ✅ CORRECT - value confirmed via `aws bedrock list-inference-profiles`
+"opus-4.7" => "global.anthropic.claude-opus-4-7".to_string(),
+```
+
+**Rule:** Before hard-coding a Bedrock inference profile ID, run:
+
+```bash
+aws bedrock list-inference-profiles --region us-west-2 2>&1 \
+  | grep '"inferenceProfileId"' | sort -u
+```
+
+Copy the exact string. Do NOT extrapolate a pattern from neighbouring models.
+
+---
+
+### 13. Family-aware LLM request parameters
+
+**Problem:** Anthropic's API contract for sampling parameters drifts across model families. Claude 4.5 and 4.6 accept a non-default `temperature`. Claude Opus 4.7 returns HTTP 400 on any non-default `temperature`, `top_p`, or `top_k`:
+
+```json
+{"error":{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."}}
+```
+
+A single hard-coded `temperature: Some(0.3)` works for older models but breaks on 4.7.
+
+```rust
+// ❌ WRONG - hard-coded temperature works for 4.5/4.6 but HTTP 400 on 4.7
+let request = BedrockRequest {
+    temperature: Some(0.3),
+    // ...
+};
+```
+
+```rust
+// ✅ CORRECT - derive from model family; drop the field entirely for 4.7
+let model_id = get_bedrock_model_id(model);
+let family = crate::llm::ModelFamily::from_model_id(&model_id);
+let temperature = if family == crate::llm::ModelFamily::Claude47 {
+    None
+} else {
+    Some(0.3)
+};
+let request = BedrockRequest {
+    temperature,
+    // ...
+};
+```
+
+Combined with `#[serde(skip_serializing_if = "Option::is_none")]` on the field, `None` cleanly drops the key from the JSON body — exactly what the 4.7 contract requires.
+
+**Rule:** Any request parameter whose acceptance varies across model families should be sourced from a `ModelFamily`-aware helper, not hard-coded. Classify the model at the top of the `complete()` call and let the family decide. Use `Option<T>` + `skip_serializing_if = "Option::is_none"` so dropping a field is a one-line change.
+
+---
+
 *Last updated: 2026-04-16*

--- a/docs/RUST_LEARNINGS.md
+++ b/docs/RUST_LEARNINGS.md
@@ -221,4 +221,23 @@ Before tagging a release:
 
 ---
 
-*Last updated: 2026-01-23*
+### 9. Back-Compat Re-Exports and Dead-Code Warnings
+
+**Problem:** When introducing a new name for an existing public constant (e.g., splitting `OPTIMIZER_SYSTEM_PROMPT` into `OPTIMIZER_SYSTEM_PROMPT_4_5` and keeping `OPTIMIZER_SYSTEM_PROMPT` as a re-export), `cargo build` emits `constant ... is never used` because the internal codebase has already been migrated to the new name.
+
+```rust
+// ❌ WARNING - dead code even though this is public
+pub const OPTIMIZER_SYSTEM_PROMPT: &str = OPTIMIZER_SYSTEM_PROMPT_4_5;
+```
+
+```rust
+// ✅ CORRECT - explicit allow for back-compat re-exports
+#[allow(dead_code)]
+pub const OPTIMIZER_SYSTEM_PROMPT: &str = OPTIMIZER_SYSTEM_PROMPT_4_5;
+```
+
+**Rule:** `pub` alone does not silence `dead_code` for binary crates. For library-style back-compat re-exports inside a binary crate, add `#[allow(dead_code)]` with a comment explaining the re-export is intentional.
+
+---
+
+*Last updated: 2026-04-16*

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -218,7 +218,7 @@ pub fn create_default_config() -> Result<PathBuf> {
 [default]
 provider = "bedrock"       # "bedrock" or "anthropic"
 model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
-# Aliases: "sonnet", "opus", "haiku", "sonnet-4.5", "opus-4.5", "haiku-4.5"
+# Aliases: "sonnet", "opus", "haiku", "sonnet-4.5", "opus-4.5", "opus-4.6", "opus-4.7", "haiku-4.5"
 
 [anthropic]
 # api_key_env = "ANTHROPIC_API_KEY"   # env var name (default)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,8 +17,9 @@ pub const MODEL_ALIASES: &[(&str, &str)] = &[
     ("sonnet-4.5", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
     ("opus", "us.anthropic.claude-opus-4-5-20251101-v1:0"),
     ("opus-4.5", "us.anthropic.claude-opus-4-5-20251101-v1:0"),
-    ("opus-4.6", "us.anthropic.claude-opus-4-6-v1"),
-    ("opus-4.7", "global.anthropic.claude-opus-4-7-v1:0"),
+    ("opus-4.6", "global.anthropic.claude-opus-4-6-v1"),
+    ("sonnet-4.6", "global.anthropic.claude-sonnet-4-6"),
+    ("opus-4.7", "global.anthropic.claude-opus-4-7"),
     ("haiku", "us.anthropic.claude-haiku-4-5-20251001-v1:0"),
     ("haiku-4.5", "us.anthropic.claude-haiku-4-5-20251001-v1:0"),
     // Reserved — not yet released. Resolver returns the alias unchanged so
@@ -61,11 +62,15 @@ mod tests {
         );
         assert_eq!(
             resolve_model_id("opus-4.6"),
-            "us.anthropic.claude-opus-4-6-v1"
+            "global.anthropic.claude-opus-4-6-v1"
+        );
+        assert_eq!(
+            resolve_model_id("sonnet-4.6"),
+            "global.anthropic.claude-sonnet-4-6"
         );
         assert_eq!(
             resolve_model_id("opus-4.7"),
-            "global.anthropic.claude-opus-4-7-v1:0"
+            "global.anthropic.claude-opus-4-7"
         );
         assert_eq!(
             resolve_model_id("us.anthropic.claude-sonnet-4-5-20250929-v1:0"),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,14 +7,24 @@ pub mod suggest;
 
 // TODO: Wire resolve_model_id() into main.rs (Phase 2 quick win)
 /// Short aliases for models
+///
+/// Note: `sonnet-4.7` and `haiku-4.7` are reserved placeholders — as of
+/// 2026-04-16 only Claude Opus 4.7 is released. Selecting either reserved
+/// alias surfaces a clear "not yet released" error at runtime
+/// (see `crate::llm::unreleased_model_error`).
 pub const MODEL_ALIASES: &[(&str, &str)] = &[
     ("sonnet", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
     ("sonnet-4.5", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
     ("opus", "us.anthropic.claude-opus-4-5-20251101-v1:0"),
     ("opus-4.5", "us.anthropic.claude-opus-4-5-20251101-v1:0"),
     ("opus-4.6", "us.anthropic.claude-opus-4-6-v1"),
+    ("opus-4.7", "global.anthropic.claude-opus-4-7-v1:0"),
     ("haiku", "us.anthropic.claude-haiku-4-5-20251001-v1:0"),
     ("haiku-4.5", "us.anthropic.claude-haiku-4-5-20251001-v1:0"),
+    // Reserved — not yet released. Resolver returns the alias unchanged so
+    // downstream guards can produce a "not yet released" error.
+    ("sonnet-4.7", "sonnet-4.7"),
+    ("haiku-4.7", "haiku-4.7"),
 ];
 
 /// Resolve a model name or alias to a full model ID
@@ -54,8 +64,20 @@ mod tests {
             "us.anthropic.claude-opus-4-6-v1"
         );
         assert_eq!(
+            resolve_model_id("opus-4.7"),
+            "global.anthropic.claude-opus-4-7-v1:0"
+        );
+        assert_eq!(
             resolve_model_id("us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
             "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
         );
+    }
+
+    #[test]
+    fn test_resolve_model_id_reserved_aliases() {
+        // sonnet-4.7 / haiku-4.7 are reserved; the resolver returns the alias
+        // unchanged so a runtime guard can produce a "not yet released" error.
+        assert_eq!(resolve_model_id("sonnet-4.7"), "sonnet-4.7");
+        assert_eq!(resolve_model_id("haiku-4.7"), "haiku-4.7");
     }
 }

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -182,13 +182,20 @@ impl LlmClient for BedrockClient {
         max_tokens: u32,
     ) -> Result<String> {
         let model_id = Self::get_bedrock_model_id(model);
+        let family = crate::llm::ModelFamily::from_model_id(&model_id);
+        // Claude 4.7 removed temperature/top_p/top_k — omit entirely.
+        let temperature = if family == crate::llm::ModelFamily::Claude47 {
+            None
+        } else {
+            Some(0.3)
+        };
 
         // Build the request body in Anthropic's Messages API format
         // (which Bedrock uses for Claude models)
         let request_body = BedrockRequest {
             anthropic_version: "bedrock-2023-05-31".to_string(),
             max_tokens,
-            temperature: Some(0.3),
+            temperature,
             system: Some(system.to_string()),
             messages: vec![BedrockMessage {
                 role: "user".to_string(),
@@ -255,7 +262,10 @@ fn get_bedrock_model_id(model: &str) -> String {
             "global.anthropic.claude-opus-4-5-20251101-v1:0".to_string()
         }
         "claude-opus-4-7" | "claude-opus-4.7" | "opus-4.7" => {
-            "global.anthropic.claude-opus-4-7-v1:0".to_string()
+            "global.anthropic.claude-opus-4-7".to_string()
+        }
+        "claude-sonnet-4-6" | "claude-sonnet-4.6" | "sonnet-4.6" => {
+            "global.anthropic.claude-sonnet-4-6".to_string()
         }
 
         // Legacy model ID format - convert to inference profile
@@ -410,7 +420,14 @@ impl LlmClient for BedrockApiKeyClient {
             }],
             inference_config: Some(ConverseInferenceConfig {
                 max_tokens,
-                temperature: Some(0.3),
+                // Claude 4.7 removed temperature/top_p/top_k — omit for 4.7.
+                temperature: if crate::llm::ModelFamily::from_model_id(&model_id)
+                    == crate::llm::ModelFamily::Claude47
+                {
+                    None
+                } else {
+                    Some(0.3)
+                },
             }),
         };
 
@@ -614,11 +631,15 @@ mod tests {
         );
         assert_eq!(
             get_bedrock_model_id("opus-4.7"),
-            "global.anthropic.claude-opus-4-7-v1:0"
+            "global.anthropic.claude-opus-4-7"
         );
         assert_eq!(
             get_bedrock_model_id("claude-opus-4-7"),
-            "global.anthropic.claude-opus-4-7-v1:0"
+            "global.anthropic.claude-opus-4-7"
+        );
+        assert_eq!(
+            get_bedrock_model_id("sonnet-4.6"),
+            "global.anthropic.claude-sonnet-4-6"
         );
     }
 

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -254,6 +254,9 @@ fn get_bedrock_model_id(model: &str) -> String {
         "claude-opus-4-5-20251101" | "claude-opus-4.5" | "opus-4.5" | "opus" => {
             "global.anthropic.claude-opus-4-5-20251101-v1:0".to_string()
         }
+        "claude-opus-4-7" | "claude-opus-4.7" | "opus-4.7" => {
+            "global.anthropic.claude-opus-4-7-v1:0".to_string()
+        }
 
         // Legacy model ID format - convert to inference profile
         "anthropic.claude-sonnet-4-5-20250929-v1:0" => {
@@ -608,6 +611,14 @@ mod tests {
         assert_eq!(
             get_bedrock_model_id("haiku-4.5"),
             "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        );
+        assert_eq!(
+            get_bedrock_model_id("opus-4.7"),
+            "global.anthropic.claude-opus-4-7-v1:0"
+        );
+        assert_eq!(
+            get_bedrock_model_id("claude-opus-4-7"),
+            "global.anthropic.claude-opus-4-7-v1:0"
         );
     }
 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -167,6 +167,8 @@ If the prompt contains XML blocks like <examples>, <example>, <instructions>, <c
 - Preserve the original intent and meaning
 - Keep the prompt practical and focused
 - Do not over-engineer or add unnecessary complexity
+- STRUCTURE: Wrap the rewrite in semantic XML tags at the top level — at minimum <task>, and whichever of <requirements>, <response_format>, <constraints>, <examples> apply. Do NOT wrap the entire output in a single outer <prompt> or <rewrite> tag; emit sibling top-level tags instead.
+- LENGTH: The rewrite MUST NOT exceed ~3x the original word count. Prefer removing scaffolding over adding it. Omit sections that are not strictly useful for this particular prompt.
 </output_requirements>"#;
 
 /// Back-compat re-export — legacy name used by callers predating the 4.7 split.
@@ -294,6 +296,8 @@ If the prompt contains XML blocks like <examples>, <example>, <instructions>,
 - Preserve the original intent and meaning
 - Keep the prompt practical and focused; do not over-engineer
 - Prefer positive examples over negative prohibitions
+- STRUCTURE: Wrap the rewrite in semantic XML tags at the top level — at minimum <task>, and whichever of <requirements>, <response_format>, <constraints>, <examples>, <scratchpad_policy> apply. Do NOT wrap the entire output in a single outer <prompt> or <rewrite> tag; emit sibling top-level tags instead.
+- LENGTH: The rewrite MUST NOT exceed ~3x the original word count. Prefer removing scaffolding over adding it. Omit sections that are not strictly useful for this particular prompt.
 </output_requirements>"#;
 
 /// Select the optimizer meta-prompt for a given family.

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -1,8 +1,18 @@
 //! LLM Client Module
 //!
-//! Provides unified interface for Claude 4.5 API access via:
+//! Provides unified interface for Claude 4.x API access via:
 //! - Anthropic API (direct)
 //! - AWS Bedrock
+//!
+//! Also hosts the model-family classifier and family-specific optimizer
+//! meta-prompts. The classifier selects which meta-prompt is used when an
+//! LLM-powered optimization is requested:
+//!
+//! - `ModelFamily::Claude45` / `Claude46` → the 4.5/4.6 meta-prompt (unchanged)
+//! - `ModelFamily::Claude47` → the 4.7 meta-prompt covering literal instruction
+//!   following, adaptive thinking guidance, effort-level awareness,
+//!   scratchpad/memory directives, condensed context, tone specification,
+//!   response-length calibration, and vision-aware instructions.
 
 mod anthropic;
 mod bedrock;
@@ -11,7 +21,7 @@ pub use anthropic::AnthropicClient;
 pub use bedrock::BedrockApiKeyClient;
 pub use bedrock::BedrockClient;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 
 /// Unified LLM client interface
@@ -31,8 +41,90 @@ pub trait LlmClient: Send + Sync {
     fn provider_name(&self) -> &str;
 }
 
-/// The meta-prompt used to optimize prompts
-pub const OPTIMIZER_SYSTEM_PROMPT: &str = r#"You are an expert prompt engineer specializing in optimizing prompts for Claude 4.5 models.
+/// Claude model family — drives which optimizer meta-prompt is used.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelFamily {
+    /// Claude 4.5 (Sonnet 4.5, Opus 4.5, Haiku 4.5). Current default.
+    Claude45,
+    /// Claude 4.6 (Opus 4.6, Sonnet 4.6). Shares the 4.5 prompting style.
+    Claude46,
+    /// Claude 4.7 (Opus 4.7 as of 2026-04-16). New prompting contract:
+    /// literal instruction following, adaptive thinking, effort awareness,
+    /// native memory/scratchpad use, condensed context, direct tone, calibrated
+    /// response length, high-resolution vision with 1:1 pixel coordinates.
+    Claude47,
+}
+
+impl ModelFamily {
+    /// Classify a model ID or alias into a family.
+    ///
+    /// The match is deliberately loose — any string containing `-4-7`, `-4.7`,
+    /// or `4-7-` counts as 4.7. Unknown inputs fall back to `Claude45` (the
+    /// historical default), which keeps existing behaviour for anything the
+    /// classifier does not recognise.
+    pub fn from_model_id(model: &str) -> Self {
+        let lower = model.to_lowercase();
+        if lower.contains("-4-7")
+            || lower.contains("-4.7")
+            || lower.contains("4-7-")
+            || lower.contains("opus-4.7")
+            || lower.contains("sonnet-4.7")
+            || lower.contains("haiku-4.7")
+        {
+            return ModelFamily::Claude47;
+        }
+        if lower.contains("-4-6") || lower.contains("-4.6") || lower.contains("4-6-") {
+            return ModelFamily::Claude46;
+        }
+        ModelFamily::Claude45
+    }
+
+    /// Human-readable label used in user messages and the optimizer prompt.
+    pub fn display_label(&self) -> &'static str {
+        match self {
+            ModelFamily::Claude45 => "Claude 4.5",
+            ModelFamily::Claude46 => "Claude 4.6",
+            ModelFamily::Claude47 => "Claude 4.7",
+        }
+    }
+}
+
+/// Return a descriptive error if the caller asked for a 4.7 model that is not
+/// yet released (as of 2026-04-16 only Claude Opus 4.7 is generally available).
+///
+/// Called by `run_optimization`, `run_interactive_mode`, and the Bedrock
+/// connectivity check so that offline/static paths are still usable while
+/// online paths fail fast with a clear message.
+pub fn unreleased_model_error(model: &str) -> Option<anyhow::Error> {
+    let lower = model.to_lowercase();
+    // Only Opus 4.7 is GA — reject explicit sonnet/haiku 4.7 aliases.
+    let asks_sonnet_47 = lower == "sonnet-4.7"
+        || lower.contains("claude-sonnet-4-7")
+        || lower.contains("claude-sonnet-4.7");
+    let asks_haiku_47 = lower == "haiku-4.7"
+        || lower.contains("claude-haiku-4-7")
+        || lower.contains("claude-haiku-4.7");
+
+    if asks_sonnet_47 {
+        return Some(anyhow!(
+            "Claude Sonnet 4.7 is not yet released (as of 2026-04-16). \
+             Only Claude Opus 4.7 is generally available.\n\
+             Use `-m opus-4.7` for Claude 4.7, or `-m sonnet` for the current Sonnet 4.5 default."
+        ));
+    }
+    if asks_haiku_47 {
+        return Some(anyhow!(
+            "Claude Haiku 4.7 is not yet released (as of 2026-04-16). \
+             Only Claude Opus 4.7 is generally available.\n\
+             Use `-m opus-4.7` for Claude 4.7, or `-m haiku` for the current Haiku 4.5 default."
+        ));
+    }
+    None
+}
+
+/// The meta-prompt used to optimize prompts for Claude 4.5 / 4.6 (unchanged
+/// from prior releases).
+pub const OPTIMIZER_SYSTEM_PROMPT_4_5: &str = r#"You are an expert prompt engineer specializing in optimizing prompts for Claude 4.5 models.
 
 Your task is to improve the given prompt according to Anthropic's official best practices:
 
@@ -77,14 +169,150 @@ If the prompt contains XML blocks like <examples>, <example>, <instructions>, <c
 - Do not over-engineer or add unnecessary complexity
 </output_requirements>"#;
 
-/// Build the user message for optimization
+/// Back-compat re-export — legacy name used by callers predating the 4.7 split.
+#[allow(dead_code)]
+pub const OPTIMIZER_SYSTEM_PROMPT: &str = OPTIMIZER_SYSTEM_PROMPT_4_5;
+
+/// The meta-prompt used to optimize prompts for the Claude 4.7 model family.
+///
+/// 4.7 changes the prompting contract in eight user-visible ways, each called
+/// out explicitly below so the optimizer can apply the right transformations
+/// instead of relying on 4.5-era scaffolding.
+pub const OPTIMIZER_SYSTEM_PROMPT_4_7: &str = r#"You are an expert prompt engineer specializing in optimizing prompts for the Claude 4.7 model family (Claude Opus 4.7 and, when released, Claude Sonnet 4.7 / Haiku 4.7).
+
+Claude 4.7 changes the prompting contract relative to 4.5/4.6. Your rewrite MUST apply the eight rules below in addition to the general 4.x best practices.
+
+<claude_4_7_rules>
+1. LITERAL INSTRUCTION FOLLOWING
+   Claude 4.7 does not silently generalize one instruction to adjacent items,
+   especially at low/medium effort. When an instruction should apply broadly,
+   state the scope explicitly (e.g., "Apply this formatting to every section,
+   not just the first one"; "Return this field for every record in the list").
+
+2. ADAPTIVE THINKING GUIDANCE
+   Extended thinking with budget_tokens is removed in 4.7. The only thinking-on
+   mode is adaptive thinking, and it is OFF by default. If the task genuinely
+   benefits from reasoning, say so in the prompt:
+   "This task involves multi-step reasoning. Think carefully through the
+   problem before responding." If the task is a simple lookup, say so:
+   "Thinking adds latency and should only be used when it will meaningfully
+   improve answer quality. When in doubt, respond directly."
+
+3. EFFORT-LEVEL AWARENESS
+   Effort (low / medium / high / xhigh / max) is respected strictly. For coding
+   and agentic workloads, recommend xhigh; for most intelligence-sensitive
+   work, recommend at minimum high. If the prompt pins the task to a low
+   effort level for latency reasons, add a targeted "think carefully" line
+   rather than prompting around under-thinking.
+
+4. SCRATCHPAD / MEMORY DIRECTIVES
+   4.7 is meaningfully better at writing and using file-system memory. For
+   long-horizon, multi-turn, or agentic prompts, add explicit scratchpad
+   directives: "Maintain a scratchpad of intermediate findings, open
+   questions, and decisions. Consult it before each new step and update it
+   after each tool call."
+
+5. CONDENSED CONTEXT (remove 4.5/4.6 scaffolding)
+   Remove scaffolding that 4.7 no longer needs: forced interim status
+   messages ("After every 3 tool calls, summarize progress"), redundant
+   self-checks ("Double-check the slide layout before returning"), and
+   verbose length-control boilerplate. 4.7 provides these natively.
+
+6. TONE SPECIFICATION
+   4.7 defaults to a direct, opinionated tone with less validation-forward
+   phrasing and fewer emoji than 4.6. If the product voice should be warmer
+   or more conversational, say so explicitly: "Use a warm, collaborative
+   tone. Acknowledge the user's framing before answering." If the default is
+   acceptable, no tone instruction is needed.
+
+7. RESPONSE-LENGTH CALIBRATION
+   4.7 calibrates length to perceived task complexity instead of defaulting
+   to a fixed verbosity. Drop blanket "be thorough" / "be concise" boilerplate.
+   If a specific length is required, use a POSITIVE example of the target
+   concision rather than "don't over-explain" negatives. Example rewrite:
+   "Provide concise, focused responses. Skip non-essential context and keep
+   examples minimal."
+
+8. VISION-AWARE INSTRUCTIONS
+   4.7 supports high-resolution images (up to 2576px / 3.75MP) and returns
+   pointing/bounding-box coordinates 1:1 with actual image pixels. Remove
+   any scale-factor conversion language from image-aware prompts. If image
+   fidelity is not needed, add: "Downsample images to 1080p before sending
+   unless pixel-level detail is required." For computer-use workloads,
+   1080p is a good default; 720p or 1366x768 for cost-sensitive flows.
+</claude_4_7_rules>
+
+<optimization_rules>
+Also apply the general 4.x prompting best practices:
+1. EXPLICITNESS: Convert vague instructions to specific, actionable ones.
+2. CONTEXT: Add motivation/reasoning when it helps Claude understand intent.
+3. POSITIVE FRAMING: Replace negative instructions with positive guidance.
+4. TOOL USAGE: Be explicit about when and why tools should be used — 4.7
+   uses tools LESS by default, so tool-heavy flows need explicit triggers.
+5. FORMAT: Clear format specs; XML tags for complex prompts.
+6. MODIFIERS: Add quality modifiers where beneficial; avoid filler.
+7. WORD CHOICE: "consider" / "evaluate" / "reflect" read better than bare
+   "think" in instructional copy.
+8. TONE: Remove aggressive emphasis (ALL CAPS, excessive !!!) — 4.7 follows
+   instructions well without it.
+</optimization_rules>
+
+<prompt_type_awareness>
+- Q&A ASSISTANT: Add response format specs, citation guidance, unknown-info
+  handling, scope boundaries. Convert role-only definitions into conditional
+  handlers ("When the user asks about X, respond with Y"). At low effort,
+  add a "think carefully" nudge for multi-step questions.
+- CODING: Recommend xhigh effort. Add exploration directives ("Read and
+  understand the relevant code before modifying"), explicit tool triggers
+  ("Use grep to locate callers before refactoring"), and
+  anti-hallucination instructions. Add scratchpad directives for long
+  sessions.
+- RESEARCH: Structured approach, hypothesis tracking, source evaluation
+  criteria. Add explicit subagent guidance if fan-out is desired — 4.7
+  spawns fewer subagents by default.
+- CREATIVE: Specify tone and audience explicitly; 4.7's default is direct
+  and less warm. If the product uses generic aesthetics, specify concrete
+  alternatives (palette hex codes, typography) rather than negatives.
+- LONG-HORIZON: Scratchpad / memory directives, incremental checkpoints,
+  explicit milestone definitions, and guidance on when user-facing progress
+  updates should be emitted.
+</prompt_type_awareness>
+
+<preserve_structure>
+If the prompt contains XML blocks like <examples>, <example>, <instructions>,
+<context>, <rules>, <format>, or <schema>:
+- PRESERVE these blocks and their content
+- ENHANCE the content within blocks rather than removing them
+- Maintain the XML structure — it provides clear semantic organization
+- Add complementary XML blocks if they improve clarity (e.g.,
+  <response_format>, <constraints>, <scratchpad_policy>)
+</preserve_structure>
+
+<output_requirements>
+- Return ONLY the optimized prompt text
+- No explanations, no preamble, no markdown fences around the output
+- Preserve the original intent and meaning
+- Keep the prompt practical and focused; do not over-engineer
+- Prefer positive examples over negative prohibitions
+</output_requirements>"#;
+
+/// Select the optimizer meta-prompt for a given family.
+pub fn system_prompt_for_family(family: ModelFamily) -> &'static str {
+    match family {
+        ModelFamily::Claude45 | ModelFamily::Claude46 => OPTIMIZER_SYSTEM_PROMPT_4_5,
+        ModelFamily::Claude47 => OPTIMIZER_SYSTEM_PROMPT_4_7,
+    }
+}
+
+/// Build the user message for optimization, tagged with the target family.
 pub fn build_optimization_message(
     original_prompt: &str,
     issues_json: &str,
     prompt_type: &str,
+    family: ModelFamily,
 ) -> String {
     format!(
-        r#"Optimize this prompt for Claude 4.5:
+        r#"Optimize this prompt for {target}:
 
 <prompt_type>{prompt_type}</prompt_type>
 
@@ -96,7 +324,8 @@ pub fn build_optimization_message(
 {issues_json}
 </detected_issues>
 
-Return the optimized prompt only."#
+Return the optimized prompt only."#,
+        target = family.display_label()
     )
 }
 
@@ -105,15 +334,117 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_build_optimization_message() {
+    fn test_build_optimization_message_4_5() {
         let message = build_optimization_message(
             "Create a dashboard",
             r#"[{"id": "EXP001", "message": "Vague instruction"}]"#,
             "coding",
+            ModelFamily::Claude45,
         );
 
         assert!(message.contains("Create a dashboard"));
         assert!(message.contains("EXP001"));
         assert!(message.contains("<prompt_type>coding</prompt_type>"));
+        assert!(message.contains("Claude 4.5"));
+    }
+
+    #[test]
+    fn test_build_optimization_message_4_7() {
+        let message =
+            build_optimization_message("Create a dashboard", "[]", "coding", ModelFamily::Claude47);
+        assert!(message.contains("Claude 4.7"));
+    }
+
+    #[test]
+    fn test_model_family_classifier_4_7() {
+        assert_eq!(
+            ModelFamily::from_model_id("global.anthropic.claude-opus-4-7-v1:0"),
+            ModelFamily::Claude47
+        );
+        assert_eq!(
+            ModelFamily::from_model_id("claude-opus-4-7"),
+            ModelFamily::Claude47
+        );
+        assert_eq!(
+            ModelFamily::from_model_id("opus-4.7"),
+            ModelFamily::Claude47
+        );
+        assert_eq!(
+            ModelFamily::from_model_id("sonnet-4.7"),
+            ModelFamily::Claude47
+        );
+    }
+
+    #[test]
+    fn test_model_family_classifier_4_6() {
+        assert_eq!(
+            ModelFamily::from_model_id("us.anthropic.claude-opus-4-6-v1"),
+            ModelFamily::Claude46
+        );
+        assert_eq!(
+            ModelFamily::from_model_id("opus-4.6"),
+            ModelFamily::Claude46
+        );
+    }
+
+    #[test]
+    fn test_model_family_classifier_default_is_4_5() {
+        assert_eq!(
+            ModelFamily::from_model_id("us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
+            ModelFamily::Claude45
+        );
+        assert_eq!(ModelFamily::from_model_id("sonnet"), ModelFamily::Claude45);
+        // Unknown → falls back to 4.5 so existing callers keep working.
+        assert_eq!(
+            ModelFamily::from_model_id("some-unknown-model-id"),
+            ModelFamily::Claude45
+        );
+    }
+
+    #[test]
+    fn test_system_prompt_for_family() {
+        let p45 = system_prompt_for_family(ModelFamily::Claude45);
+        let p46 = system_prompt_for_family(ModelFamily::Claude46);
+        let p47 = system_prompt_for_family(ModelFamily::Claude47);
+
+        assert!(p45.contains("Claude 4.5 models"));
+        // 4.5 and 4.6 share the same meta-prompt for now.
+        assert!(std::ptr::eq(p45, p46));
+        assert!(p47.contains("Claude 4.7"));
+        assert!(p47.contains("LITERAL INSTRUCTION FOLLOWING"));
+        assert!(p47.contains("ADAPTIVE THINKING"));
+        assert!(p47.contains("SCRATCHPAD"));
+        assert!(p47.contains("VISION-AWARE"));
+    }
+
+    #[test]
+    fn test_unreleased_model_error_sonnet_4_7() {
+        let err = unreleased_model_error("sonnet-4.7").expect("should flag sonnet-4.7");
+        let msg = format!("{err}");
+        assert!(msg.contains("Sonnet 4.7"));
+        assert!(msg.contains("not yet released"));
+        assert!(msg.contains("opus-4.7"));
+    }
+
+    #[test]
+    fn test_unreleased_model_error_haiku_4_7() {
+        let err = unreleased_model_error("haiku-4.7").expect("should flag haiku-4.7");
+        let msg = format!("{err}");
+        assert!(msg.contains("Haiku 4.7"));
+        assert!(msg.contains("not yet released"));
+    }
+
+    #[test]
+    fn test_unreleased_model_error_opus_4_7_is_fine() {
+        assert!(unreleased_model_error("opus-4.7").is_none());
+        assert!(unreleased_model_error("global.anthropic.claude-opus-4-7-v1:0").is_none());
+    }
+
+    #[test]
+    fn test_unreleased_model_error_existing_models_unaffected() {
+        assert!(unreleased_model_error("sonnet").is_none());
+        assert!(unreleased_model_error("opus-4.5").is_none());
+        assert!(unreleased_model_error("opus-4.6").is_none());
+        assert!(unreleased_model_error("haiku-4.5").is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 //! copt - Claude Optimizer
 //!
-//! A beautiful CLI tool to optimize prompts for Claude 4.5 family of models.
+//! A beautiful CLI tool to optimize prompts for the Claude 4.x family of models (4.5, 4.6, and 4.7).
 //! Analyzes prompts and rewrites them according to Anthropic's official best practices.
 
 use anyhow::{Context, Result};
@@ -20,12 +20,12 @@ mod utils;
 // Re-export types from analyzer for use throughout the crate
 pub use analyzer::{Issue, Severity};
 
-/// Claude Optimizer - A beautiful CLI tool to optimize prompts for Claude 4.5 models
+/// Claude Optimizer - A beautiful CLI tool to optimize prompts for Claude 4.x models (4.5 / 4.6 / 4.7)
 #[derive(Parser, Debug)]
 #[command(
     name = "copt",
     version,
-    about = "⚡ Optimize prompts for Claude 4.5 models",
+    about = "⚡ Optimize prompts for Claude 4.x models (4.5, 4.6, 4.7)",
     after_help = "Examples:\n  copt \"Your prompt here\"\n  copt -f prompt.txt\n  copt -f prompt.txt --offline\n  cat prompt.txt | copt"
 )]
 struct Cli {
@@ -193,6 +193,17 @@ async fn main() -> Result<()> {
 
     // Resolve model aliases (e.g., "sonnet" → full Bedrock ARN)
     cli.model = cli::resolve_model_id(&cli.model);
+
+    // Guard against selecting Claude 4.7 family models that are not yet
+    // released. As of 2026-04-16 only Claude Opus 4.7 is GA — Sonnet 4.7 and
+    // Haiku 4.7 error with a clear message. The guard is skipped in offline
+    // mode so static analysis with a 4.7 target is still useful.
+    if !cli.offline {
+        if let Some(err) = llm::unreleased_model_error(&cli.model) {
+            eprintln!("{} {}", "Error:".red().bold(), err);
+            std::process::exit(1);
+        }
+    }
 
     // Interactive mode requires TTY
     if cli.interactive && !io::stdout().is_terminal() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,21 @@ async fn main() -> Result<()> {
         check_provider_connectivity(&cli).await?;
     }
 
+    // Tip: when targeting 4.7 with a non-Opus-class rewriter, suggest the
+    // Opus-class rewriters which empirically produce the cleanest 4.7 output
+    // (Haiku over-elaborates; Sonnet occasionally drops XML structure).
+    if !cli.quiet
+        && cli.format != OutputFormat::Quiet
+        && parse_target_family(&cli.target) == Some(llm::ModelFamily::Claude47)
+        && !is_opus_rewriter(&cli.model)
+    {
+        eprintln!(
+            "{} Targeting Claude 4.7 with `{}`. For the cleanest 4.7 rewrite we recommend an Opus-class rewriter (`-m opus-4.6` or `-m opus-4.7`).",
+            "ℹ".bright_cyan(),
+            cli.model
+        );
+    }
+
     // Get the input prompt
     let prompt = get_input_prompt(&cli).await?;
 
@@ -267,6 +282,14 @@ fn parse_target_family(target: &str) -> Option<llm::ModelFamily> {
         "4.7" => Some(llm::ModelFamily::Claude47),
         _ => None, // "auto" or anything else
     }
+}
+
+/// Return true when the resolved model ID refers to an Opus-class rewriter.
+/// Used to print a "recommend Opus rewriter" hint when the user targets 4.7
+/// with a smaller model.
+fn is_opus_rewriter(model: &str) -> bool {
+    let lower = model.to_lowercase();
+    lower.contains("opus")
 }
 
 fn apply_config_defaults(cli: &mut Cli, matches: &clap::ArgMatches) {
@@ -847,11 +870,32 @@ async fn handle_output(cli: &Cli, result: &OptimizationResult) -> Result<()> {
             })?;
         }
 
-        // Derive original prompt path from optimized path
+        // Derive original prompt path from optimized path.
+        // When the filename contains the `_optimized.txt` sentinel (auto-save
+        // convention), swap to `_original.txt`. For an explicit `-o <path>`
+        // that doesn't follow that convention, append `.original` before the
+        // extension so we don't clobber the optimized file.
         let original_path = {
             let filename = path.file_name().unwrap().to_string_lossy();
-            let original_filename = filename.replace("_optimized.txt", "_original.txt");
-            path.with_file_name(original_filename)
+            if filename.contains("_optimized.txt") {
+                let original_filename = filename.replace("_optimized.txt", "_original.txt");
+                path.with_file_name(original_filename)
+            } else {
+                let stem = path
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                let ext = path
+                    .extension()
+                    .map(|e| e.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                let original_filename = if ext.is_empty() {
+                    format!("{stem}.original")
+                } else {
+                    format!("{stem}.original.{ext}")
+                };
+                path.with_file_name(original_filename)
+            }
         };
 
         // Write the optimized prompt

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ struct Cli {
     )]
     provider: Provider,
 
-    /// Model ID or alias
+    /// Model ID or alias (controls which model performs the rewrite)
     #[arg(
         short,
         long,
@@ -67,6 +67,20 @@ struct Cli {
         default_value = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
     )]
     model: String,
+
+    /// Target Claude family whose best-practices the rewrite should optimize for.
+    /// `auto` (default) infers the family from --model. Choose explicitly to decouple
+    /// the "rewriter" model from the "target" family (e.g., let Sonnet 4.5 rewrite your
+    /// prompt for Opus 4.7: `-m sonnet -t 4.7`).
+    #[arg(
+        short = 't',
+        long = "target",
+        value_name = "FAMILY",
+        value_parser = ["auto", "4.5", "4.6", "4.7"],
+        default_value = "auto",
+        hide_default_value = true
+    )]
+    target: String,
 
     /// AWS region for Bedrock
     #[arg(long, default_value = "us-west-2", hide_default_value = true)]
@@ -244,6 +258,17 @@ async fn main() -> Result<()> {
 
 /// Apply config file defaults for CLI fields the user didn't explicitly set.
 /// CLI args always take precedence over config values.
+/// Parse the `--target` / `-t` CLI value into an explicit `ModelFamily`,
+/// or `None` for `auto` (meaning: derive from the `--model` flag).
+fn parse_target_family(target: &str) -> Option<llm::ModelFamily> {
+    match target {
+        "4.5" => Some(llm::ModelFamily::Claude45),
+        "4.6" => Some(llm::ModelFamily::Claude46),
+        "4.7" => Some(llm::ModelFamily::Claude47),
+        _ => None, // "auto" or anything else
+    }
+}
+
 fn apply_config_defaults(cli: &mut Cli, matches: &clap::ArgMatches) {
     use clap::parser::ValueSource;
 
@@ -678,9 +703,15 @@ async fn run_optimization(cli: &Cli, prompt: &str) -> Result<OptimizationResult>
             }
         };
 
-        let result =
-            optimizer::optimize_with_llm(prompt, &issues, client.as_ref(), &cli.model, prompt_type)
-                .await?;
+        let result = optimizer::optimize_with_llm(
+            prompt,
+            &issues,
+            client.as_ref(),
+            &cli.model,
+            prompt_type,
+            parse_target_family(&cli.target),
+        )
+        .await?;
         if let Some(s) = spinner {
             tui::renderer::stop_optimizing_spinner(s);
         }
@@ -917,6 +948,7 @@ async fn run_interactive_mode(cli: &Cli, prompt: &str) -> Result<()> {
             client.as_ref(),
             &cli.model,
             prompt_type,
+            parse_target_family(&cli.target),
         )
         .await
         {

--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use crate::analyzer::{Issue, PromptType, Severity};
-use crate::llm::{build_optimization_message, LlmClient, OPTIMIZER_SYSTEM_PROMPT};
+use crate::llm::{build_optimization_message, system_prompt_for_family, LlmClient, ModelFamily};
 
 /// Static optimization using rule-based transformations
 ///
@@ -29,11 +29,31 @@ pub fn optimize_static(prompt: &str, issues: &[Issue]) -> Result<String> {
         }
     }
 
-    // Append applicable enhancement hints
+    // Append applicable enhancement hints (family-neutral set).
     let enhancements = get_applicable_enhancements(&result);
     if !enhancements.is_empty() {
         for enhancement in &enhancements {
             result.push_str(enhancement);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Family-aware variant of `optimize_static` that additionally appends the
+/// Claude 4.7-specific hints (literal scope, adaptive thinking, scratchpad,
+/// vision) when targeting 4.7. Callers that don't care about the family can
+/// keep using `optimize_static`.
+pub fn optimize_static_for_family(
+    prompt: &str,
+    issues: &[Issue],
+    family: ModelFamily,
+) -> Result<String> {
+    let mut result = optimize_static(prompt, issues)?;
+
+    if family == ModelFamily::Claude47 {
+        for hint in get_family_enhancements(&result, family) {
+            result.push_str(hint);
         }
     }
 
@@ -261,6 +281,10 @@ fn transform_overtriggering_language(prompt: &str) -> String {
 }
 
 /// Optimize a prompt using an LLM
+///
+/// The target `model` string drives which model family's meta-prompt is used
+/// (see `ModelFamily::from_model_id`). Unknown model IDs fall back to the
+/// 4.5 meta-prompt, preserving historical behaviour.
 pub async fn optimize_with_llm(
     prompt: &str,
     issues: &[Issue],
@@ -268,18 +292,24 @@ pub async fn optimize_with_llm(
     model: &str,
     prompt_type: PromptType,
 ) -> Result<String> {
-    // First apply static transformations for quick wins
-    let partially_optimized = optimize_static(prompt, issues)?;
+    let family = ModelFamily::from_model_id(model);
+
+    // First apply static transformations for quick wins (family-aware so 4.7
+    // static hints make it into the user message as enhancement context).
+    let partially_optimized = optimize_static_for_family(prompt, issues, family)?;
 
     // Build the user message with detected issues, enhancements, and prompt type
     let issues_summary = format_issues_for_llm(issues);
-    let enhancements = get_applicable_enhancements(&partially_optimized);
-    let enhancements_summary = if enhancements.is_empty() {
+    let mut all_enhancements = get_applicable_enhancements(&partially_optimized);
+    if family == ModelFamily::Claude47 {
+        all_enhancements.extend(get_family_enhancements(&partially_optimized, family));
+    }
+    let enhancements_summary = if all_enhancements.is_empty() {
         String::new()
     } else {
         format!(
             "\n\nSuggested enhancements to incorporate:\n{}",
-            enhancements
+            all_enhancements
                 .iter()
                 .map(|e| format!("- {}", e.trim()))
                 .collect::<Vec<_>>()
@@ -291,11 +321,13 @@ pub async fn optimize_with_llm(
         &partially_optimized,
         &format!("{}{}", issues_summary, enhancements_summary),
         prompt_type_str,
+        family,
     );
 
-    // Call the LLM
+    // Call the LLM using the family-specific meta-prompt.
+    let system_prompt = system_prompt_for_family(family);
     let optimized = client
-        .complete(OPTIMIZER_SYSTEM_PROMPT, &user_message, model, 4096)
+        .complete(system_prompt, &user_message, model, 4096)
         .await?;
 
     // Clean up any accidental wrapping the LLM might add
@@ -416,6 +448,114 @@ pub fn get_applicable_enhancements(prompt: &str) -> Vec<&'static str> {
         .filter(|e| (e.condition)(prompt))
         .map(|e| e.template)
         .collect()
+}
+
+/// Claude 4.7-specific enhancement hints.
+///
+/// These are gated behind `ModelFamily::Claude47` so 4.5/4.6 output is
+/// unchanged. Each hint targets one of the eight 4.7 prompting rules.
+pub fn get_family_enhancements(prompt: &str, family: ModelFamily) -> Vec<&'static str> {
+    if family != ModelFamily::Claude47 {
+        return Vec::new();
+    }
+
+    let lower = prompt.to_lowercase();
+    let mut hints: Vec<&'static str> = Vec::new();
+
+    // 1. Literal instruction following — state scope explicitly.
+    if lower.contains(" each ")
+        || lower.contains(" every ")
+        || lower.contains(" all ")
+        || lower.contains(" any ")
+    {
+        hints.push(
+            "\n\nWhen an instruction should apply broadly, state the scope explicitly (e.g., \"apply to every section, not just the first\"). Claude 4.7 interprets prompts literally and will not silently generalize.",
+        );
+    }
+
+    // 2. Adaptive thinking — nudge based on reasoning keywords.
+    if lower.contains("think")
+        || lower.contains("reason")
+        || lower.contains("analyze")
+        || lower.contains("plan")
+    {
+        hints.push(
+            "\n\nIf the task genuinely benefits from reasoning, say so: \"This task involves multi-step reasoning. Think carefully through the problem before responding.\" Adaptive thinking is off by default on Claude 4.7.",
+        );
+    }
+
+    // 3. Effort-level awareness for coding / agentic work.
+    if lower.contains("code")
+        || lower.contains("refactor")
+        || lower.contains("implement")
+        || lower.contains("agent")
+        || lower.contains("tool")
+    {
+        hints.push(
+            "\n\nFor coding and agentic workloads on Claude 4.7, xhigh effort is the recommended default; use at minimum high effort for intelligence-sensitive work.",
+        );
+    }
+
+    // 4. Scratchpad / memory directives for long-horizon work.
+    if prompt.len() > 500
+        || lower.contains("long")
+        || lower.contains("multi-step")
+        || lower.contains("agent")
+        || lower.contains("across turns")
+    {
+        hints.push(
+            "\n\nMaintain a scratchpad of intermediate findings, open questions, and decisions. Consult it before each new step and update it after each tool call. Claude 4.7 is meaningfully better at writing and using file-system memory.",
+        );
+    }
+
+    // 5. Condensed context — remove 4.5/4.6 scaffolding.
+    if lower.contains("double-check")
+        || lower.contains("status update")
+        || lower.contains("summarize progress")
+        || lower.contains("after every")
+    {
+        hints.push(
+            "\n\nClaude 4.7 provides native progress updates and self-checking — remove forced interim-status or self-verification scaffolding left over from 4.5/4.6 prompts.",
+        );
+    }
+
+    // 6. Tone specification when a voice is implied.
+    if lower.contains("friendly")
+        || lower.contains("warm")
+        || lower.contains("helpful tone")
+        || lower.contains("conversational")
+    {
+        hints.push(
+            "\n\nClaude 4.7 defaults to a direct, opinionated tone with fewer emoji than 4.6. If a warmer voice is required, state it explicitly, e.g., \"Use a warm, collaborative tone. Acknowledge the user's framing before answering.\"",
+        );
+    }
+
+    // 7. Response-length calibration.
+    if lower.contains("concise")
+        || lower.contains("brief")
+        || lower.contains("short")
+        || lower.contains("verbose")
+        || lower.contains("thorough")
+    {
+        hints.push(
+            "\n\nClaude 4.7 calibrates response length to perceived task complexity. Prefer a positive example of the target concision over \"don't over-explain\" negatives, e.g., \"Provide concise, focused responses. Skip non-essential context and keep examples minimal.\"",
+        );
+    }
+
+    // 8. Vision-aware instructions.
+    if lower.contains("image")
+        || lower.contains("screenshot")
+        || lower.contains("pixel")
+        || lower.contains("bounding box")
+        || lower.contains("coordinate")
+        || lower.contains("vision")
+    {
+        hints.push(
+            "\n\nClaude 4.7 supports high-resolution images up to 2576px / 3.75MP and returns pointing/bounding-box coordinates 1:1 with actual image pixels. Remove any scale-factor conversion logic. If pixel-level fidelity is not required, downsample images to 1080p before sending to control token usage.",
+        );
+    }
+
+    hints
 }
 
 #[cfg(test)]

--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -389,6 +389,22 @@ fn clean_llm_output(output: &str) -> String {
         result = result[..result.len() - 3].trim_end().to_string();
     }
 
+    // Strip outer <prompt>...</prompt> or <rewrite>...</rewrite> wrappers that
+    // some rewriter models (Haiku 4.5 in particular) emit despite the
+    // meta-prompt explicitly forbidding it. We only strip when the ENTIRE
+    // output is wrapped in one such tag — semantic top-level tags like
+    // <task>, <examples>, <instructions> are never stripped.
+    for wrapper in ["prompt", "rewrite", "optimized_prompt", "output"] {
+        let open = format!("<{wrapper}>");
+        let close = format!("</{wrapper}>");
+        if result.starts_with(&open) && result.trim_end().ends_with(&close) {
+            let trimmed = result.trim_end();
+            result = trimmed[open.len()..trimmed.len() - close.len()]
+                .trim()
+                .to_string();
+        }
+    }
+
     result
 }
 
@@ -644,6 +660,34 @@ mod tests {
             "Do this task"
         );
         assert_eq!(clean_llm_output("```\nCode here\n```"), "Code here");
+    }
+
+    #[test]
+    fn test_clean_llm_output_strips_prompt_wrapper() {
+        let wrapped = "<prompt>\n<task>Do X</task>\n</prompt>";
+        let cleaned = clean_llm_output(wrapped);
+        assert!(!cleaned.starts_with("<prompt>"));
+        assert!(cleaned.starts_with("<task>"));
+        assert!(cleaned.contains("Do X"));
+    }
+
+    #[test]
+    fn test_clean_llm_output_preserves_semantic_tags() {
+        // Semantic top-level tags like <task> must NEVER be stripped,
+        // even if the entire output starts and ends with them.
+        let semantic = "<task>Do X</task>";
+        assert_eq!(clean_llm_output(semantic), semantic);
+
+        let with_examples = "<examples><example>ok</example></examples>";
+        assert_eq!(clean_llm_output(with_examples), with_examples);
+    }
+
+    #[test]
+    fn test_clean_llm_output_strips_other_wrappers() {
+        for wrapper in ["rewrite", "optimized_prompt", "output"] {
+            let input = format!("<{w}>body</{w}>", w = wrapper);
+            assert_eq!(clean_llm_output(&input), "body");
+        }
     }
 
     #[test]

--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -282,17 +282,20 @@ fn transform_overtriggering_language(prompt: &str) -> String {
 
 /// Optimize a prompt using an LLM
 ///
-/// The target `model` string drives which model family's meta-prompt is used
-/// (see `ModelFamily::from_model_id`). Unknown model IDs fall back to the
-/// 4.5 meta-prompt, preserving historical behaviour.
+/// The `target_family` parameter controls WHICH Claude family's best-practices
+/// the rewrite is optimized for. Pass `None` to infer the family from `model`
+/// (historical behaviour) or `Some(family)` to decouple "rewriter model" from
+/// "target family" — e.g., using Sonnet 4.5 to rewrite a prompt for Opus 4.7.
+/// Unknown model IDs fall back to the 4.5 meta-prompt.
 pub async fn optimize_with_llm(
     prompt: &str,
     issues: &[Issue],
     client: &dyn LlmClient,
     model: &str,
     prompt_type: PromptType,
+    target_family: Option<ModelFamily>,
 ) -> Result<String> {
-    let family = ModelFamily::from_model_id(model);
+    let family = target_family.unwrap_or_else(|| ModelFamily::from_model_id(model));
 
     // First apply static transformations for quick wins (family-aware so 4.7
     // static hints make it into the user message as enhancement context).

--- a/src/tui/linear.rs
+++ b/src/tui/linear.rs
@@ -72,7 +72,7 @@ fn render_header(w: &mut impl Write, model: &Model) -> io::Result<()> {
     writeln!(
         w,
         "  {}",
-        format!("v{} • Optimize prompts for Claude 4.5", version).bright_black()
+        format!("v{} • Optimize prompts for Claude 4.x", version).bright_black()
     )?;
     writeln!(w)?;
 

--- a/src/tui/snapshots/copt__tui__snapshot_tests__main_view_analysis_done.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__main_view_analysis_done.snap
@@ -3,7 +3,7 @@ source: src/tui/snapshot_tests.rs
 expression: output
 ---
 ⚡  CLAUDE PROMPT OPTIMIZER v0.3.2                                               
-Optimize prompts for Claude 4.5                                                 
+Optimize prompts for Claude 4.x                                                 
 📥  Input: test_prompt.txt (53 chars, 12 tokens)                                 
 ────────────────────────────────────────────────────────────────────────────────
 ┌ 📊  Analysis Results ─────────────────────────────────────────────────────────┐

--- a/src/tui/snapshots/copt__tui__snapshot_tests__main_view_done.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__main_view_done.snap
@@ -3,7 +3,7 @@ source: src/tui/snapshot_tests.rs
 expression: output
 ---
 ⚡  CLAUDE PROMPT OPTIMIZER v0.3.2                                               
-Optimize prompts for Claude 4.5                                                 
+Optimize prompts for Claude 4.x                                                 
 📥  Input: test_prompt.txt (53 chars, 12 tokens)                                 
 ────────────────────────────────────────────────────────────────────────────────
 ┌ 📊  Analysis Results ─────────────────────────────────────────────────────────┐

--- a/src/tui/snapshots/copt__tui__snapshot_tests__no_issues.snap
+++ b/src/tui/snapshots/copt__tui__snapshot_tests__no_issues.snap
@@ -3,7 +3,7 @@ source: src/tui/snapshot_tests.rs
 expression: output
 ---
 ⚡  CLAUDE PROMPT OPTIMIZER v0.3.2                                               
-Optimize prompts for Claude 4.5                                                 
+Optimize prompts for Claude 4.x                                                 
 📥  Input: stdin (30 chars, 5 tokens)                                            
 ────────────────────────────────────────────────────────────────────────────────
 ┌ 📊  Analysis Results ─────────────────────────────────────────────────────────┐

--- a/src/tui/widgets/header.rs
+++ b/src/tui/widgets/header.rs
@@ -31,7 +31,7 @@ pub fn render_header(frame: &mut Frame, area: Rect, model: &Model) {
     let subtitle = if model.offline_mode {
         "Static analysis only (no LLM calls)"
     } else {
-        "Optimize prompts for Claude 4.5"
+        "Optimize prompts for Claude 4.x"
     };
 
     // Input info line


### PR DESCRIPTION
# feat: Claude 4.7 family support (Opus 4.7 GA + reserved Sonnet/Haiku 4.7)

## Summary

Adds first-class support for the Claude 4.7 model family. As of 2026-04-16 only
**Claude Opus 4.7** (`claude-opus-4-7`) is generally available — Sonnet 4.7 and
Haiku 4.7 are registered as reserved aliases that surface a clear
"not yet released" error when selected.

When a 4.7 model is the target, optimization routes through a new
Claude 4.7-specific meta-prompt that applies the eight new prompting rules
Anthropic calls out in the 4.7 migration guide. Existing 4.5 and 4.6
optimization paths are untouched — default model is still
`us.anthropic.claude-sonnet-4-5-20250929-v1:0`.

A follow-up fix commit corrects the Bedrock inference profile IDs (verified
live against `aws bedrock list-inference-profiles`), adds the `-t` / `--target`
flag to decouple the rewriter model from the target family, and drops
`temperature` from 4.7 requests to comply with the 4.7 sampling-parameter
contract.

## Motivation

Claude Opus 4.7 changes the prompting contract in ways that break several
optimizations `copt` was emitting for 4.5/4.6:

- It follows instructions literally at low/medium effort and will not silently
  generalize across items.
- Extended thinking with `budget_tokens` is removed — adaptive thinking + the
  `effort` parameter is the only knob.
- It handles interim status updates and self-checks natively; 4.5/4.6
  scaffolding for these is now noise.
- It has a direct, less-warm default tone and calibrated response length.
- It is the first Claude model with high-resolution image support (2576px /
  3.75MP) and 1:1 pixel coordinate mapping.

`copt` now detects the target family from the model ID (or from the explicit
`--target` flag) and swaps the optimizer meta-prompt (and static enhancement
hints) accordingly.

## Changes

### Core — model family classifier (`src/llm/mod.rs`)

- New `ModelFamily` enum: `Claude45`, `Claude46`, `Claude47`.
- `ModelFamily::from_model_id(&str)` classifier (loose match on `-4-7` /
  `-4.7` / alias forms). Unknown inputs fall back to `Claude45` so historic
  callers are unaffected.
- New `OPTIMIZER_SYSTEM_PROMPT_4_7` — 4.7-specific meta-prompt covering all
  eight 4.7 prompting rules (literal instruction following, adaptive thinking
  guidance, effort-level awareness, scratchpad/memory directives, condensed
  context, tone specification, response-length calibration, vision-aware
  instructions).
- `OPTIMIZER_SYSTEM_PROMPT_4_5` is the renamed former prompt; a
  `#[allow(dead_code)] pub const OPTIMIZER_SYSTEM_PROMPT` back-compat re-export
  preserves the legacy symbol.
- `system_prompt_for_family(family)` selector.
- `build_optimization_message(..., family)` now labels the user message with
  the target family's display label (e.g., "Optimize this prompt for
  Claude 4.7:").
- `unreleased_model_error(model) -> Option<anyhow::Error>` flags
  `sonnet-4.7` and `haiku-4.7` with a descriptive message and a suggested
  alternative alias.

### Aliases and Bedrock mapping

- `src/cli/mod.rs::MODEL_ALIASES` — corrected and expanded after live
  verification against `aws bedrock list-inference-profiles --region us-west-2`:
  - `opus-4.7` → `global.anthropic.claude-opus-4-7`
    (initial guess `global.anthropic.claude-opus-4-7-v1:0` returned HTTP 400;
    the profile has no `-v1:0` suffix)
  - `opus-4.6` → `global.anthropic.claude-opus-4-6-v1`
    (corrected from `us.anthropic.*`)
  - `sonnet-4.6` → `global.anthropic.claude-sonnet-4-6`
    (new alias discovered during fix verification)
  - `sonnet-4.7` / `haiku-4.7` remain reserved — resolver returns the alias
    unchanged so the guard can surface the "not yet released" error.
- `src/llm/bedrock.rs::get_bedrock_model_id`: match arms for
  `claude-opus-4-7` / `claude-opus-4.7` / `opus-4.7` map to the corrected
  Bedrock inference profile `global.anthropic.claude-opus-4-7`.

### Claude 4.7 sampling parameters (`src/llm/bedrock.rs`, `src/llm/mod.rs`)

Per the Claude 4.7 migration guide, sending non-default `temperature`,
`top_p`, or `top_k` values returns HTTP 400 on Opus 4.7. Both
`BedrockClient` (SigV4) and `BedrockApiKeyClient` (Bearer) now omit
`temperature` when `ModelFamily::from_model_id` resolves to `Claude47`.
The `Option<f32>` fields decorated with `#[serde(skip_serializing_if =
"Option::is_none")]` ensure the field is completely absent from the JSON
body rather than serialized as `null`.

### Output quality hardening (`src/optimizer/mod.rs`, `src/llm/mod.rs`)

#### Meta-prompt STRUCTURE and LENGTH rules

Both `OPTIMIZER_SYSTEM_PROMPT_4_5` and `OPTIMIZER_SYSTEM_PROMPT_4_7` gain two
new MANDATORY rules inside `<output_requirements>`:

- **STRUCTURE** — the rewrite must use top-level semantic XML tags (`<task>`,
  `<requirements>`, `<response_format>`, `<constraints>`, etc.). The output
  MUST NOT be wrapped in an outer `<prompt>` or `<rewrite>` tag.
- **LENGTH** — the rewrite must not exceed ~3× the original word count. Prefer
  removing scaffolding over adding it.

These rules address observed LLM behaviour where outputs were 4–5× the
original length and wrapped in a spurious outer `<prompt>` element.

#### Output post-processor wrapper stripping

New `clean_llm_output()` function in `src/optimizer/mod.rs`. When the
**entire** response body is wrapped in one of these outer tags, the wrapper
is stripped before the result is returned or saved:

- `<prompt>…</prompt>`
- `<rewrite>…</rewrite>`
- `<optimized_prompt>…</optimized_prompt>`
- `<output>…</output>`

Semantic top-level tags (`<task>`, `<examples>`, etc.) are never stripped —
the function only fires when the single root element is one of the known
wrapper names.

#### UX tip for non-Opus rewriters targeting 4.7

When `-t 4.7` is combined with a non-Opus rewriter (e.g., `-m sonnet`,
`-m haiku-4.5`), a one-line `ℹ` tip is printed to stderr:

```
ℹ  For cleanest Claude 4.7 output, consider an Opus-class rewriter (opus-4.6 or opus-4.7).
```

The tip is silent when an Opus rewriter is used or when the target is 4.5/4.6.
This makes the recommendation discoverable without being intrusive.

#### `-o <path>` bug fix

Previously, `copt -f prompt.txt -m <model> -o /tmp/foo.txt` wrote the
**original** prompt to `/tmp/foo.txt` instead of the optimized one. Root
cause: the original-copy path derivation only handled the auto-save
convention (`_optimized.txt` suffix); for explicit `-o` paths, both the
optimized write and the original write targeted the same path, and the
original write happened second, clobbering the result.

Fixed: explicit `-o` paths now produce `<stem>.original.<ext>` for the
original copy, mirroring the auto-save convention.

#### Empirical validation — 8-run smoke matrix

A live Bedrock smoke matrix (8 runs across opus-4.7, opus-4.6, sonnet-4.6,
haiku-4.5, sonnet-4.5) confirmed the fixes:

| Metric | Before | After |
|--------|--------|-------|
| Pass rate | 0/8 (blocked by `-o` bug) | **8/8** |
| Top-level tag | mixed | all start with `<task>` |
| Outer-wrapper violations | present | **0** |
| Max length ratio | 4–5× | **2.13×** |
| Tip shown (3 qualifying runs) | n/a | ✅ correct |

### Decoupling rewriter from target (`-t` / `--target`)

The new `-t` / `--target` CLI flag lets users pick the optimization target
family independently of the model that performs the rewrite:

| Value | Behaviour |
|-------|-----------|
| `auto` (default) | Derive target family from `--model`, matching prior behaviour |
| `4.5` | Force `ModelFamily::Claude45` regardless of `--model` |
| `4.6` | Force `ModelFamily::Claude46` regardless of `--model` |
| `4.7` | Force `ModelFamily::Claude47` regardless of `--model` |

The canonical use-case is using fast, cheap Sonnet 4.5 to rewrite a prompt
using Opus 4.7 best-practices:

```bash
copt -f prompt.txt -m sonnet -t 4.7
```

Internally, `optimize_with_llm` gains a `target_family: Option<ModelFamily>`
parameter. `None` preserves historical behaviour (derive family from the model
string); `Some(family)` overrides it. The only caller is `main.rs`, so no
downstream crate consumers are affected.

### Optimizer routing (`src/optimizer/mod.rs`)

- `optimize_with_llm(...)` resolves `ModelFamily` from the target model string
  (or `--target` override) and uses `system_prompt_for_family` instead of the
  hard-coded 4.5 prompt.
- New `get_family_enhancements(prompt, family)` appends 4.7-specific hints
  (literal scope, adaptive thinking, effort level, scratchpad, condensed
  context, tone, length calibration, vision) to the user message when
  targeting Opus 4.7.
- New `optimize_static_for_family(...)` thin wrapper that layers the 4.7
  hints onto the existing `optimize_static` output. Family-agnostic
  `optimize_static` is unchanged.

### Runtime guard (`src/main.rs`)

- After alias resolution, calls `llm::unreleased_model_error` and exits 1
  with a descriptive message when Sonnet 4.7 or Haiku 4.7 is targeted.
- `--offline` bypasses the guard so static analysis still works against an
  unreleased target family.
- Parses the new `--target` flag and passes the resolved `Option<ModelFamily>`
  through to `optimize_with_llm`.

### UX / docs

- README: Model Aliases table gains rows for `opus-4.7`, `opus-4.6`, and
  `sonnet-4.6`; new "Claude 4.7 support" subsection explains the 8 rules, the
  unreleased guard, and the `--target` flag; tagline updated to
  "Claude 4.x models (4.5, 4.6, and 4.7)".
- CHANGELOG: new `[Unreleased]` section with Added / Changed / Technical
  subsections covering both commits.
- `--config-init` template: `opus-4.6` and `opus-4.7` added to the alias
  comment.
- TUI banner: "Optimize prompts for Claude 4.5" → "Claude 4.x" (same length,
  so snapshot diffs are a clean literal swap in 3 snapshot files).
- `docs/RUST_LEARNINGS.md`: new section 9 on back-compat re-exports and
  `dead_code` warnings; date bumped to 2026-04-16.
- `.gitignore`: new rules excluding `docs/SEED_PROMPT.txt` and
  `docs/SEED_PROMPT-*.txt` (local scratch seed prompts, not for tracking).

### Tests

10 new unit tests in commits 1–2; +3 in commit 3; test suite 101 → 117 (all passing):

- `llm::tests::test_model_family_classifier_4_7`
- `llm::tests::test_model_family_classifier_4_6`
- `llm::tests::test_model_family_classifier_default_is_4_5`
- `llm::tests::test_system_prompt_for_family`
- `llm::tests::test_build_optimization_message_4_5`
- `llm::tests::test_build_optimization_message_4_7`
- `llm::tests::test_unreleased_model_error_sonnet_4_7`
- `llm::tests::test_unreleased_model_error_haiku_4_7`
- `llm::tests::test_unreleased_model_error_opus_4_7_is_fine`
- `llm::tests::test_unreleased_model_error_existing_models_unaffected`

Plus assertions added to the existing `cli::tests::test_resolve_model_id`
and new `test_resolve_model_id_reserved_aliases`, and the Bedrock mapping
test now covers `opus-4.7` / `claude-opus-4-7`.

The follow-up fix commit (c653f12) did not add new test categories — the
existing `test_model_family_classifier_*` tests already cover the classifier
used to gate `temperature`, and the `--target` flag is end-to-end
smoke-tested.

The third commit (657063b) adds 3 new tests in `src/optimizer/mod.rs::tests`
(114 → 117):

- `test_clean_llm_output_strips_prompt_wrapper`
- `test_clean_llm_output_preserves_semantic_tags`
- `test_clean_llm_output_strips_other_wrappers`

`make ci-release` green (full clean rebuild on Rust 1.94.1).

## Family detection rules

```
contains "-4-7" / "-4.7" / "4-7-" / "opus-4.7" / "sonnet-4.7" / "haiku-4.7"  → Claude47
contains "-4-6" / "-4.6" / "4-6-" / "sonnet-4.6" / "opus-4.6"                → Claude46
anything else                                                                  → Claude45   (default)
```

## Usage examples

```bash
# Optimize a prompt for Claude Opus 4.7 (GA) — rewriter is also Opus 4.7
copt -f prompt.txt -m opus-4.7

# Use cheap/fast Sonnet 4.5 as the rewriter, but target 4.7 best-practices
copt -f prompt.txt -m sonnet -t 4.7

# Use Opus 4.7 as the rewriter, but emit 4.5-oriented optimizations
copt -f prompt.txt -m opus-4.7 -t 4.5

# Sonnet 4.7 not yet released — fails fast online, works offline
copt -f prompt.txt -m sonnet-4.7
# Error: Claude Sonnet 4.7 is not yet released (as of 2026-04-16). ...

copt -f prompt.txt -m sonnet-4.7 --offline
# Analyzes locally using the 4.7 target family.
```

## Backward compatibility

- Default model is still `us.anthropic.claude-sonnet-4-5-20250929-v1:0`.
- Unknown model IDs fall back to `ModelFamily::Claude45` and the 4.5
  meta-prompt — existing behaviour preserved.
- `OPTIMIZER_SYSTEM_PROMPT` is still exported (points to the 4.5 prompt).
- `optimize_with_llm` gains a new `target_family: Option<ModelFamily>`
  parameter — this is a **breaking change to the internal function signature**.
  The only caller is `main.rs`; public exports of the crate are unaffected.
- TUI snapshot diffs are limited to the header literal swap (same string
  length, same layout).

## Testing

- [x] `make ci-quiet` / `make ci-release` — fmt, clippy (`-D warnings`), build, 117 tests passing
- [x] Offline smoke: `cargo run -- -f /tmp/seed47.txt -m opus-4.7 --offline`
- [x] Guard smoke: `copt -m sonnet-4.7` exits 1 with descriptive error
- [x] Guard bypass: `copt -m sonnet-4.7 --offline` succeeds as designed
- [x] Online smoke — `./target/release/copt -f test_prompt.txt -m opus-4.7`
      succeeds against real Bedrock. Rewrite output carries 4.7 signature
      lines: *"Provide concise, focused responses. Skip non-essential context
      and keep examples minimal."* + explicit
      *"Recommended effort level: high (xhigh if agentic)"*.
- [x] `--target` smoke — `./target/release/copt -f test_prompt.txt -m sonnet
      -t 4.7` shows `us.anthropic.claude-sonnet-4-5-20250929-v1:0` as the
      calling model while the rewrite output contains 4.7 guidance; confirms
      rewriter/target decoupling works end-to-end.
- [x] 8/8 smoke matrix against live Bedrock (opus-4.7, opus-4.6, sonnet-4.6,
      haiku-4.5, sonnet-4.5); all outputs start with `<task>`, zero wrapper
      violations, max length ratio 2.13×.
- [x] `-o` path bug reproduced and fixed — optimized content now correctly
      written to the explicit output path; original saved as `<stem>.original.<ext>`.

## Diff stats

```
15 files changed, 792 insertions(+), 41 deletions(-)
```

## Files

| Area | Files |
|------|-------|
| Core | `src/llm/mod.rs`, `src/llm/bedrock.rs` |
| Routing | `src/optimizer/mod.rs` |
| CLI / config | `src/cli/mod.rs`, `src/cli/config.rs`, `src/main.rs` |
| TUI | `src/tui/linear.rs`, `src/tui/widgets/header.rs`, 3 snapshot files |
| Docs | `README.md`, `CHANGELOG.md`, `docs/RUST_LEARNINGS.md`, `docs/tmp/feature-claude-4-7-support/*` |
| Infra | `.gitignore` |

## Commits

| SHA | Message |
|-----|---------|
| `1a731b5` | feat: add Claude 4.7 family support (Opus 4.7 GA; Sonnet/Haiku 4.7 reserved) |
| `c653f12` | fix: correct Opus 4.7 inference profile ID; add --target flag; drop temperature on 4.7 |
| `657063b` | fix: output quality + -o path bug |
